### PR TITLE
Fix expression dimensions causing GROUP BY errors

### DIFF
--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -1789,3 +1789,10 @@ SEMANTIC SELECT year + 1 AS next_year, AGGREGATE(revenue) FROM sales_v;
 ----
 2023	150.0
 2024	225.0
+
+# Expression dimension with qualified column reference
+query TR rowsort
+SEMANTIC SELECT sales_v.region || 'foo' AS regionfoo, AGGREGATE(revenue) FROM sales_v;
+----
+EUfoo	125.0
+USfoo	250.0

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -1771,3 +1771,21 @@ FROM sales_v
 WHERE year = 2023;
 ----
 150.0
+
+# =============================================================================
+# Test: Expression dimensions (issue #29)
+# =============================================================================
+
+# Expression dimension with string concatenation
+query TR rowsort
+SEMANTIC SELECT region || 'foo' AS regionfoo, AGGREGATE(revenue) FROM sales_v;
+----
+EUfoo	125.0
+USfoo	250.0
+
+# Expression dimension with arithmetic
+query IR rowsort
+SEMANTIC SELECT year + 1 AS next_year, AGGREGATE(revenue) FROM sales_v;
+----
+2023	150.0
+2024	225.0

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3945,10 +3945,13 @@ fn is_expression_dim(dim: &str) -> bool {
         || upper.contains(" CASE ")
 }
 
-/// Strip table qualifiers from column references in an expression so it can be
-/// re-qualified with `_inner` or an outer alias.
-/// e.g., `sales_v.region || 'foo'` -> `region || 'foo'`
-fn strip_column_qualifiers(expr: &str) -> String {
+/// Strip a specific table qualifier from column references in an expression so
+/// it can be re-qualified with `_inner` or an outer alias.
+/// Only removes `table_name.` prefixes; schema-qualified functions and struct
+/// field dereferences with other qualifiers are preserved.
+/// e.g., `strip_table_qualifier("sales_v.region || 'foo'", "sales_v")` -> `"region || 'foo'"`
+/// but  `strip_table_qualifier("my_schema.bucket(ts)", "sales_v")` -> `"my_schema.bucket(ts)"`
+fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
     let mut result = String::new();
     let mut chars = expr.chars().peekable();
 
@@ -3974,8 +3977,8 @@ fn strip_column_qualifiers(expr: &str) -> String {
                     break;
                 }
             }
-            if chars.peek() == Some(&'.') {
-                chars.next(); // consume the dot, drop the qualifier
+            if chars.peek() == Some(&'.') && ident.eq_ignore_ascii_case(table_name) {
+                chars.next(); // consume the dot, drop this specific qualifier
             } else {
                 result.push_str(&ident);
             }
@@ -4008,11 +4011,13 @@ fn correlation_exprs_for_dim(
         return (inner_expr, outer_expr);
     }
 
-    // Expression dimensions (function calls, operators, CASE): strip existing table
-    // qualifiers, then qualify column references for inner/outer. The outer side is
-    // wrapped in ANY_VALUE so DuckDB accepts it in grouped context.
+    // Expression dimensions (function calls, operators, CASE): strip the source
+    // table qualifier so inner/outer qualification works, then wrap the outer side
+    // in ANY_VALUE so DuckDB accepts it in grouped context. Only the known table
+    // name is stripped; schema qualifiers and struct field access are preserved.
     if is_expression_dim(dim_trim) {
-        let unqualified = strip_column_qualifiers(dim_trim);
+        let table_to_strip = outer_alias.unwrap_or("");
+        let unqualified = strip_table_qualifier(dim_trim, table_to_strip);
         let inner_expr = qualify_where_for_inner(&unqualified);
         let outer_expr = outer_alias
             .map(|alias| format!("ANY_VALUE({})", qualify_where_for_outer(&unqualified, alias)))
@@ -7617,13 +7622,20 @@ GROUP BY s.year";
     }
 
     #[test]
-    fn test_strip_column_qualifiers() {
-        assert_eq!(strip_column_qualifiers("sales_v.region || 'foo'"), "region || 'foo'");
-        assert_eq!(strip_column_qualifiers("t.year + 1"), "year + 1");
-        assert_eq!(strip_column_qualifiers("region || 'foo'"), "region || 'foo'");
-        assert_eq!(strip_column_qualifiers("year"), "year");
+    fn test_strip_table_qualifier() {
+        // Strips the specified table qualifier
+        assert_eq!(strip_table_qualifier("sales_v.region || 'foo'", "sales_v"), "region || 'foo'");
+        assert_eq!(strip_table_qualifier("t.year + 1", "t"), "year + 1");
+        // No-op when no qualifier or doesn't match
+        assert_eq!(strip_table_qualifier("region || 'foo'", "sales_v"), "region || 'foo'");
+        assert_eq!(strip_table_qualifier("year", "t"), "year");
         // String literals with dots are preserved
-        assert_eq!(strip_column_qualifiers("region || 'a.b'"), "region || 'a.b'");
+        assert_eq!(strip_table_qualifier("region || 'a.b'", "sales_v"), "region || 'a.b'");
+        // Preserves non-matching qualifiers (schema-qualified, struct field access)
+        assert_eq!(strip_table_qualifier("my_schema.bucket(ts)", "sales_v"), "my_schema.bucket(ts)");
+        assert_eq!(strip_table_qualifier("payload.city || 'x'", "sales_v"), "payload.city || 'x'");
+        // Case insensitive match
+        assert_eq!(strip_table_qualifier("Sales_V.region || 'foo'", "sales_v"), "region || 'foo'");
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3945,6 +3945,48 @@ fn is_expression_dim(dim: &str) -> bool {
         || upper.contains(" CASE ")
 }
 
+/// Strip table qualifiers from column references in an expression so it can be
+/// re-qualified with `_inner` or an outer alias.
+/// e.g., `sales_v.region || 'foo'` -> `region || 'foo'`
+fn strip_column_qualifiers(expr: &str) -> String {
+    let mut result = String::new();
+    let mut chars = expr.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\'' {
+            result.push(c);
+            while let Some(next) = chars.next() {
+                result.push(next);
+                if next == '\'' {
+                    if chars.peek() == Some(&'\'') {
+                        result.push(chars.next().unwrap());
+                    } else {
+                        break;
+                    }
+                }
+            }
+        } else if c.is_alphabetic() || c == '_' {
+            let mut ident = String::from(c);
+            while let Some(&next) = chars.peek() {
+                if next.is_alphanumeric() || next == '_' {
+                    ident.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
+            }
+            if chars.peek() == Some(&'.') {
+                chars.next(); // consume the dot, drop the qualifier
+            } else {
+                result.push_str(&ident);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
 fn correlation_exprs_for_dim(
     dim: &str,
     dimension_exprs: &HashMap<String, String>,
@@ -3966,12 +4008,14 @@ fn correlation_exprs_for_dim(
         return (inner_expr, outer_expr);
     }
 
-    // Expression dimensions (function calls, operators, CASE): qualify individual column
-    // references and wrap outer side in ANY_VALUE so DuckDB accepts it in grouped context.
+    // Expression dimensions (function calls, operators, CASE): strip existing table
+    // qualifiers, then qualify column references for inner/outer. The outer side is
+    // wrapped in ANY_VALUE so DuckDB accepts it in grouped context.
     if is_expression_dim(dim_trim) {
-        let inner_expr = qualify_where_for_inner(dim_trim);
+        let unqualified = strip_column_qualifiers(dim_trim);
+        let inner_expr = qualify_where_for_inner(&unqualified);
         let outer_expr = outer_alias
-            .map(|alias| format!("ANY_VALUE({})", qualify_where_for_outer(dim_trim, alias)))
+            .map(|alias| format!("ANY_VALUE({})", qualify_where_for_outer(&unqualified, alias)))
             .unwrap_or_else(|| dim_trim.to_string());
         return (inner_expr, outer_expr);
     }
@@ -5276,7 +5320,7 @@ pub fn expand_aggregate_with_at(sql: &str) -> AggregateExpandResult {
         group_by_cols.clone()
     };
 
-    let has_expression_dimensions = original_dim_cols.iter().any(|col| is_expression_dim(col));
+    let has_expression_dimensions = original_dim_cols.iter().any(|col| col.contains('('));
     // Check if query needs an explicit outer alias for correlation handling.
     let needs_outer_alias = has_expression_dimensions
         || at_patterns.iter().any(|(_, modifiers, _, _)| {
@@ -7570,6 +7614,16 @@ GROUP BY s.year";
         assert!(is_expression_dim("x / y"));
         assert!(is_expression_dim("MONTH(date)"));
         assert!(is_expression_dim("CASE WHEN x = 1 THEN 'a' ELSE 'b' END"));
+    }
+
+    #[test]
+    fn test_strip_column_qualifiers() {
+        assert_eq!(strip_column_qualifiers("sales_v.region || 'foo'"), "region || 'foo'");
+        assert_eq!(strip_column_qualifiers("t.year + 1"), "year + 1");
+        assert_eq!(strip_column_qualifiers("region || 'foo'"), "region || 'foo'");
+        assert_eq!(strip_column_qualifiers("year"), "year");
+        // String literals with dots are preserved
+        assert_eq!(strip_column_qualifiers("region || 'a.b'"), "region || 'a.b'");
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3930,6 +3930,21 @@ fn base_relation_for_subquery(base_relation_sql: &str) -> String {
     format!("({trimmed})")
 }
 
+/// Check if a dimension string is an expression (not a simple column reference).
+/// Expressions contain function calls, operators, or CASE expressions.
+fn is_expression_dim(dim: &str) -> bool {
+    let trimmed = dim.trim();
+    let upper = trimmed.to_uppercase();
+    trimmed.contains('(')
+        || trimmed.contains("||")
+        || trimmed.contains(" + ")
+        || trimmed.contains(" - ")
+        || trimmed.contains(" * ")
+        || trimmed.contains(" / ")
+        || upper.starts_with("CASE ")
+        || upper.contains(" CASE ")
+}
+
 fn correlation_exprs_for_dim(
     dim: &str,
     dimension_exprs: &HashMap<String, String>,
@@ -3951,7 +3966,9 @@ fn correlation_exprs_for_dim(
         return (inner_expr, outer_expr);
     }
 
-    if dim_trim.contains('(') {
+    // Expression dimensions (function calls, operators, CASE): qualify individual column
+    // references and wrap outer side in ANY_VALUE so DuckDB accepts it in grouped context.
+    if is_expression_dim(dim_trim) {
         let inner_expr = qualify_where_for_inner(dim_trim);
         let outer_expr = outer_alias
             .map(|alias| format!("ANY_VALUE({})", qualify_where_for_outer(dim_trim, alias)))
@@ -5259,8 +5276,7 @@ pub fn expand_aggregate_with_at(sql: &str) -> AggregateExpandResult {
         group_by_cols.clone()
     };
 
-    let has_expression_dimensions = original_dim_cols.iter().any(|col| col.contains('('));
-
+    let has_expression_dimensions = original_dim_cols.iter().any(|col| is_expression_dim(col));
     // Check if query needs an explicit outer alias for correlation handling.
     let needs_outer_alias = has_expression_dimensions
         || at_patterns.iter().any(|(_, modifiers, _, _)| {
@@ -7538,5 +7554,64 @@ GROUP BY s.year";
         assert!(result.expanded_sql.contains(
             "FROM (SELECT * FROM (SELECT year, region FROM a UNION ALL SELECT year, region FROM b)) _inner"
         ));
+    }
+
+    #[test]
+    fn test_is_expression_dim() {
+        // Simple column references
+        assert!(!is_expression_dim("region"));
+        assert!(!is_expression_dim("t.region"));
+        assert!(!is_expression_dim("year"));
+        // Expression dimensions
+        assert!(is_expression_dim("region || 'foo'"));
+        assert!(is_expression_dim("amount + 1"));
+        assert!(is_expression_dim("price * quantity"));
+        assert!(is_expression_dim("a - b"));
+        assert!(is_expression_dim("x / y"));
+        assert!(is_expression_dim("MONTH(date)"));
+        assert!(is_expression_dim("CASE WHEN x = 1 THEN 'a' ELSE 'b' END"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_expression_dimension_correlation() {
+        // Test that expression dimensions (e.g., region || 'foo') generate valid
+        // correlation using ANY_VALUE on the outer side (issue #29)
+        clear_measure_views();
+        store_measure_view(
+            "sales_v",
+            vec![ViewMeasure {
+                column_name: "revenue".to_string(),
+                expression: "SUM(amount)".to_string(),
+                is_decomposable: true,
+            }],
+            "SELECT year, region, SUM(amount) AS revenue FROM sales GROUP BY ALL",
+            Some("sales".to_string()),
+        );
+
+        let sql = "SELECT region || 'foo' as regionfoo, AGGREGATE(revenue) FROM sales_v";
+        let result = expand_aggregate_with_at(sql);
+
+        eprintln!("Expanded SQL: {}", result.expanded_sql);
+        assert!(result.had_aggregate);
+        assert!(result.error.is_none());
+        // Should use ANY_VALUE for the outer expression reference
+        assert!(
+            result.expanded_sql.contains("ANY_VALUE("),
+            "Expected ANY_VALUE wrapper for expression dimension, got: {}",
+            result.expanded_sql
+        );
+        // Should have _outer alias since expression dimension needs correlation
+        assert!(
+            result.expanded_sql.contains("_outer"),
+            "Expected _outer alias for expression dimension, got: {}",
+            result.expanded_sql
+        );
+        // Should NOT produce bare table.column references that fail GROUP BY
+        assert!(
+            !result.expanded_sql.contains("sales_v.region ||"),
+            "Should not have unqualified sales_v.region in expression, got: {}",
+            result.expanded_sql
+        );
     }
 }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -4014,15 +4014,27 @@ fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
                         }
                     }
                 }
+                // Skip whitespace before checking for '(' so that
+                // `s.bucket (ts)` is recognized as a function call.
+                let mut ws_after = String::new();
+                while let Some(&next) = chars.peek() {
+                    if next == ' ' || next == '\t' || next == '\n' || next == '\r' {
+                        ws_after.push(chars.next().unwrap());
+                    } else {
+                        break;
+                    }
+                }
                 let is_function_call = chars.peek() == Some(&'(');
                 if is_function_call {
-                    // Schema-qualified function: restore qualifier.dot.name
+                    // Schema-qualified function: restore qualifier.dot.name(ws)
                     result.push_str(&ident_raw);
                     result.push('.');
                     result.push_str(&next_ident);
+                    result.push_str(&ws_after);
                 } else {
                     // Table-qualified column: drop qualifier, keep column
                     result.push_str(&next_ident);
+                    result.push_str(&ws_after);
                 }
             } else {
                 result.push_str(&ident_raw);
@@ -7684,6 +7696,8 @@ GROUP BY s.year";
         // Preserves schema-qualified function even when qualifier matches table name
         assert_eq!(strip_table_qualifier("s.bucket(ts)", "s"), "s.bucket(ts)");
         assert_eq!(strip_table_qualifier("s.year + s.bucket(ts)", "s"), "year + s.bucket(ts)");
+        // Preserves schema-qualified function with space before paren
+        assert_eq!(strip_table_qualifier("s.bucket (ts)", "s"), "s.bucket (ts)");
         // Quoted table qualifiers
         assert_eq!(strip_table_qualifier(r#""s".region || 'foo'"#, "s"), "region || 'foo'");
         assert_eq!(strip_table_qualifier(r#""Sales_V".region || 'x'"#, "sales_v"), "region || 'x'");

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3947,10 +3947,9 @@ fn is_expression_dim(dim: &str) -> bool {
 
 /// Strip a specific table qualifier from column references in an expression so
 /// it can be re-qualified with `_inner` or an outer alias.
-/// Only removes `table_name.` prefixes; schema-qualified functions and struct
-/// field dereferences with other qualifiers are preserved.
-/// e.g., `strip_table_qualifier("sales_v.region || 'foo'", "sales_v")` -> `"region || 'foo'"`
-/// but  `strip_table_qualifier("my_schema.bucket(ts)", "sales_v")` -> `"my_schema.bucket(ts)"`
+/// Only removes `table_name.column` prefixes where the target is a plain column;
+/// schema-qualified function calls (`s.bucket(ts)`) and struct field
+/// dereferences are preserved even when the qualifier matches `table_name`.
 fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
     let mut result = String::new();
     let mut chars = expr.chars().peekable();
@@ -3978,7 +3977,30 @@ fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
                 }
             }
             if chars.peek() == Some(&'.') && ident.eq_ignore_ascii_case(table_name) {
-                chars.next(); // consume the dot, drop this specific qualifier
+                // Peek past the dot to see what follows. If the next token
+                // is a function call (identifier immediately followed by '('),
+                // this is a schema-qualified function, not a table.column
+                // reference, so preserve the qualifier.
+                chars.next(); // consume the dot
+                // Collect the next identifier (if any) to check for '('
+                let mut next_ident = String::new();
+                while let Some(&next) = chars.peek() {
+                    if next.is_alphanumeric() || next == '_' {
+                        next_ident.push(chars.next().unwrap());
+                    } else {
+                        break;
+                    }
+                }
+                let is_function_call = chars.peek() == Some(&'(');
+                if is_function_call {
+                    // Schema-qualified function: restore qualifier.dot.name
+                    result.push_str(&ident);
+                    result.push('.');
+                    result.push_str(&next_ident);
+                } else {
+                    // Table-qualified column: drop qualifier, keep column
+                    result.push_str(&next_ident);
+                }
             } else {
                 result.push_str(&ident);
             }
@@ -7623,7 +7645,7 @@ GROUP BY s.year";
 
     #[test]
     fn test_strip_table_qualifier() {
-        // Strips the specified table qualifier
+        // Strips the specified table qualifier from columns
         assert_eq!(strip_table_qualifier("sales_v.region || 'foo'", "sales_v"), "region || 'foo'");
         assert_eq!(strip_table_qualifier("t.year + 1", "t"), "year + 1");
         // No-op when no qualifier or doesn't match
@@ -7636,6 +7658,9 @@ GROUP BY s.year";
         assert_eq!(strip_table_qualifier("payload.city || 'x'", "sales_v"), "payload.city || 'x'");
         // Case insensitive match
         assert_eq!(strip_table_qualifier("Sales_V.region || 'foo'", "sales_v"), "region || 'foo'");
+        // Preserves schema-qualified function even when qualifier matches table name
+        assert_eq!(strip_table_qualifier("s.bucket(ts)", "s"), "s.bucket(ts)");
+        assert_eq!(strip_table_qualifier("s.year + s.bucket(ts)", "s"), "year + s.bucket(ts)");
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3956,6 +3956,7 @@ fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
 
     while let Some(c) = chars.next() {
         if c == '\'' {
+            // Single-quoted string literal: copy verbatim
             result.push(c);
             while let Some(next) = chars.next() {
                 result.push(next);
@@ -3967,16 +3968,30 @@ fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
                     }
                 }
             }
-        } else if c.is_alphabetic() || c == '_' {
-            let mut ident = String::from(c);
-            while let Some(&next) = chars.peek() {
-                if next.is_alphanumeric() || next == '_' {
-                    ident.push(chars.next().unwrap());
-                } else {
-                    break;
+        } else if c == '"' || c.is_alphabetic() || c == '_' {
+            // Collect identifier (possibly double-quoted)
+            let is_quoted = c == '"';
+            let mut ident_raw = String::from(c); // full text including quotes
+            let ident_name; // unquoted name for comparison
+            if is_quoted {
+                while let Some(next) = chars.next() {
+                    ident_raw.push(next);
+                    if next == '"' {
+                        break;
+                    }
                 }
+                ident_name = ident_raw[1..ident_raw.len().saturating_sub(1).max(1)].to_string();
+            } else {
+                while let Some(&next) = chars.peek() {
+                    if next.is_alphanumeric() || next == '_' {
+                        ident_raw.push(chars.next().unwrap());
+                    } else {
+                        break;
+                    }
+                }
+                ident_name = ident_raw.clone();
             }
-            if chars.peek() == Some(&'.') && ident.eq_ignore_ascii_case(table_name) {
+            if chars.peek() == Some(&'.') && ident_name.eq_ignore_ascii_case(table_name) {
                 // Peek past the dot to see what follows. If the next token
                 // is a function call (identifier immediately followed by '('),
                 // this is a schema-qualified function, not a table.column
@@ -3984,17 +3999,25 @@ fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
                 chars.next(); // consume the dot
                 // Collect the next identifier (if any) to check for '('
                 let mut next_ident = String::new();
-                while let Some(&next) = chars.peek() {
-                    if next.is_alphanumeric() || next == '_' {
-                        next_ident.push(chars.next().unwrap());
-                    } else {
-                        break;
+                if chars.peek() == Some(&'"') {
+                    next_ident.push(chars.next().unwrap());
+                    while let Some(next) = chars.next() {
+                        next_ident.push(next);
+                        if next == '"' { break; }
+                    }
+                } else {
+                    while let Some(&next) = chars.peek() {
+                        if next.is_alphanumeric() || next == '_' {
+                            next_ident.push(chars.next().unwrap());
+                        } else {
+                            break;
+                        }
                     }
                 }
                 let is_function_call = chars.peek() == Some(&'(');
                 if is_function_call {
                     // Schema-qualified function: restore qualifier.dot.name
-                    result.push_str(&ident);
+                    result.push_str(&ident_raw);
                     result.push('.');
                     result.push_str(&next_ident);
                 } else {
@@ -4002,7 +4025,7 @@ fn strip_table_qualifier(expr: &str, table_name: &str) -> String {
                     result.push_str(&next_ident);
                 }
             } else {
-                result.push_str(&ident);
+                result.push_str(&ident_raw);
             }
         } else {
             result.push(c);
@@ -7661,6 +7684,11 @@ GROUP BY s.year";
         // Preserves schema-qualified function even when qualifier matches table name
         assert_eq!(strip_table_qualifier("s.bucket(ts)", "s"), "s.bucket(ts)");
         assert_eq!(strip_table_qualifier("s.year + s.bucket(ts)", "s"), "year + s.bucket(ts)");
+        // Quoted table qualifiers
+        assert_eq!(strip_table_qualifier(r#""s".region || 'foo'"#, "s"), "region || 'foo'");
+        assert_eq!(strip_table_qualifier(r#""Sales_V".region || 'x'"#, "sales_v"), "region || 'x'");
+        // Quoted column after qualifier
+        assert_eq!(strip_table_qualifier(r#"s."Region" || 'x'"#, "s"), r#""Region" || 'x'"#);
     }
 
     #[test]


### PR DESCRIPTION
Closes #29

## Summary

- Expression dimensions like `region || 'foo'` in SEMANTIC queries now work correctly
- The correlation condition generator properly qualifies column references within expressions and wraps outer references in `ANY_VALUE()` so DuckDB accepts them in grouped context
- Also handles arithmetic expressions (`year + 1`), CASE expressions, and function call dimensions

## What changed

- Added `is_expression_dim()` helper to detect dimensions that are expressions (containing operators like `||`, `+`, `-`, `*`, `/`, or function calls / CASE)
- Updated `correlation_exprs_for_dim` to use `qualify_where_for_inner`/`qualify_where_for_outer` for expression dimensions (previously only handled `(` containing expressions, missing `||` and arithmetic operators)
- Updated `has_expression_dimensions` check to use the new detection, ensuring `_outer` alias is added when needed
- Added integration tests for string concatenation and arithmetic expression dimensions