### PR TITLE
Fix ORDER BY with named aggregates that expand to subqueries

### DIFF
--- a/include/yardstick_ffi.h
+++ b/include/yardstick_ffi.h
@@ -178,6 +178,13 @@ void yardstick_free_aggregate_list(YardstickAggregateCallList* list);
 YardstickSelectInfo* yardstick_parse_select(const char* sql);
 
 /**
+ * Inline SELECT aliases inside complex ORDER BY expressions when they reference
+ * a SELECT alias whose expression contains a subquery. Returns NULL when no
+ * rewrite is needed or parsing fails.
+ */
+char* yardstick_inline_order_by_subquery_aliases(const char* sql);
+
+/**
  * Free a select info structure.
  */
 void yardstick_free_select_info(YardstickSelectInfo* info);

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -63,6 +63,7 @@ extern "C" {
         char* (*replace_range)(const char*, uint32_t, uint32_t, const char*),
         char* (*apply_replacements)(const char*, const YardstickReplacement*, size_t),
         char* (*qualify_expression)(const char*, const char*),
+        char* (*inline_order_by_subquery_aliases)(const char*),
         void (*free_string)(char*),
         char* (*expand_aggregate_call)(const char*, const char*, const YardstickAtModifier*, size_t, const char*, const char*, const char*, const char* const*, size_t)
     );
@@ -635,6 +636,7 @@ static void LoadInternal(ExtensionLoader &loader) {
         yardstick_replace_range,
         yardstick_apply_replacements,
         yardstick_qualify_expression,
+        yardstick_inline_order_by_subquery_aliases,
         yardstick_free_string,
         yardstick_expand_aggregate_call
     );

--- a/src/yardstick_parser_ffi.cpp
+++ b/src/yardstick_parser_ffi.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/parser/expression/window_expression.hpp"
 #include "duckdb/parser/expression/between_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
 #include "duckdb/parser/tableref/joinref.hpp"
@@ -37,6 +38,7 @@
 #include <cstring>
 #include <vector>
 #include <string>
+#include <unordered_map>
 
 using namespace duckdb;
 
@@ -55,6 +57,22 @@ static char* safe_strdup(const std::string& s) {
 
 static bool IsBoundaryChar(char c) {
     return !std::isalnum(static_cast<unsigned char>(c)) && c != '_';
+}
+
+static std::string NormalizeAliasName(const std::string &alias) {
+    return StringUtil::Lower(alias);
+}
+
+static bool IsPotentialOrderAliasRef(const ColumnRefExpression &colref, std::string &alias_name) {
+    if (!colref.IsQualified()) {
+        alias_name = colref.GetColumnName();
+        return true;
+    }
+    if (colref.column_names.size() == 2 && StringUtil::CIEquals(colref.GetTableName(), "alias")) {
+        alias_name = colref.GetColumnName();
+        return true;
+    }
+    return false;
 }
 
 static size_t SkipWhitespaceAndComments(const std::string& sql, size_t idx) {
@@ -1217,6 +1235,143 @@ extern "C" void yardstick_free_select_info(YardstickSelectInfo* info) {
     free(const_cast<char*>(info->error));
 
     delete info;
+}
+
+struct SelectAliasEntry {
+    ParsedExpression* expression;
+    bool has_subquery;
+};
+
+using SelectAliasMap = std::unordered_map<std::string, SelectAliasEntry>;
+
+static bool FindSelectAliasRef(const ParsedExpression &expr, const SelectAliasMap &aliases,
+                               SelectAliasMap::const_iterator &alias_entry) {
+    if (expr.expression_class != ExpressionClass::COLUMN_REF) {
+        return false;
+    }
+
+    std::string alias_name;
+    auto &colref = expr.Cast<ColumnRefExpression>();
+    if (!IsPotentialOrderAliasRef(colref, alias_name)) {
+        return false;
+    }
+
+    alias_entry = aliases.find(NormalizeAliasName(alias_name));
+    return alias_entry != aliases.end();
+}
+
+static bool IsSimpleSelectAliasOrder(const ParsedExpression &expr, const SelectAliasMap &aliases) {
+    SelectAliasMap::const_iterator alias_entry;
+    return FindSelectAliasRef(expr, aliases, alias_entry);
+}
+
+static bool ReferencesSubqueryAlias(const ParsedExpression &expr, const SelectAliasMap &aliases) {
+    SelectAliasMap::const_iterator alias_entry;
+    if (FindSelectAliasRef(expr, aliases, alias_entry) && alias_entry->second.has_subquery) {
+        return true;
+    }
+
+    bool found = false;
+    ParsedExpressionIterator::EnumerateChildren(expr, [&](const ParsedExpression &child) {
+        if (!found && ReferencesSubqueryAlias(child, aliases)) {
+            found = true;
+        }
+    });
+    return found;
+}
+
+static bool InlineSelectAliases(unique_ptr<ParsedExpression> &expr, const SelectAliasMap &aliases) {
+    if (!expr) {
+        return false;
+    }
+
+    SelectAliasMap::const_iterator alias_entry;
+    if (FindSelectAliasRef(*expr, aliases, alias_entry)) {
+        auto replacement = alias_entry->second.expression->Copy();
+        replacement->ClearAlias();
+        expr = std::move(replacement);
+        return true;
+    }
+
+    bool changed = false;
+    ParsedExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<ParsedExpression> &child) {
+        if (InlineSelectAliases(child, aliases)) {
+            changed = true;
+        }
+    });
+    return changed;
+}
+
+//=============================================================================
+// FFI Implementation: yardstick_inline_order_by_subquery_aliases
+//=============================================================================
+
+extern "C" char* yardstick_inline_order_by_subquery_aliases(const char* sql) {
+    if (!sql) {
+        return nullptr;
+    }
+
+    try {
+        Parser parser;
+        parser.ParseQuery(sql);
+        if (parser.statements.empty()) {
+            return nullptr;
+        }
+
+        auto& stmt = parser.statements[0];
+        if (stmt->type != StatementType::SELECT_STATEMENT) {
+            return nullptr;
+        }
+
+        auto* select_stmt = static_cast<SelectStatement*>(stmt.get());
+        if (!select_stmt->node || select_stmt->node->type != QueryNodeType::SELECT_NODE) {
+            return nullptr;
+        }
+
+        auto* select_node = static_cast<SelectNode*>(select_stmt->node.get());
+        SelectAliasMap aliases;
+        bool has_subquery_alias = false;
+        for (auto& expr : select_node->select_list) {
+            if (expr->alias.empty()) {
+                continue;
+            }
+            bool has_subquery = expr->HasSubquery();
+            aliases[NormalizeAliasName(expr->alias)] = SelectAliasEntry { expr.get(), has_subquery };
+            has_subquery_alias = has_subquery_alias || has_subquery;
+        }
+
+        if (!has_subquery_alias || aliases.empty()) {
+            return nullptr;
+        }
+
+        bool changed = false;
+        for (auto& modifier : select_node->modifiers) {
+            if (modifier->type != ResultModifierType::ORDER_MODIFIER) {
+                continue;
+            }
+
+            auto& order_modifier = modifier->Cast<OrderModifier>();
+            for (auto& order : order_modifier.orders) {
+                if (!order.expression) {
+                    continue;
+                }
+                if (IsSimpleSelectAliasOrder(*order.expression, aliases)) {
+                    continue;
+                }
+                if (!ReferencesSubqueryAlias(*order.expression, aliases)) {
+                    continue;
+                }
+                changed = InlineSelectAliases(order.expression, aliases) || changed;
+            }
+        }
+
+        if (!changed) {
+            return nullptr;
+        }
+        return safe_strdup(stmt->ToString());
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 //=============================================================================

--- a/src/yardstick_parser_ffi.cpp
+++ b/src/yardstick_parser_ffi.cpp
@@ -1267,6 +1267,36 @@ static bool IsSimpleSelectAliasOrder(const ParsedExpression &expr, const SelectA
     return FindSelectAliasRef(expr, aliases, alias_entry);
 }
 
+static void EnumerateOrderAliasScopeChildren(
+    const ParsedExpression &expr,
+    const std::function<void(const ParsedExpression &child)> &callback
+) {
+    if (expr.GetExpressionClass() == ExpressionClass::SUBQUERY) {
+        auto &subquery_expr = expr.Cast<SubqueryExpression>();
+        if (subquery_expr.child) {
+            callback(*subquery_expr.child);
+        }
+        return;
+    }
+
+    ParsedExpressionIterator::EnumerateChildren(expr, callback);
+}
+
+static void EnumerateOrderAliasScopeChildren(
+    ParsedExpression &expr,
+    const std::function<void(unique_ptr<ParsedExpression> &child)> &callback
+) {
+    if (expr.GetExpressionClass() == ExpressionClass::SUBQUERY) {
+        auto &subquery_expr = expr.Cast<SubqueryExpression>();
+        if (subquery_expr.child) {
+            callback(subquery_expr.child);
+        }
+        return;
+    }
+
+    ParsedExpressionIterator::EnumerateChildren(expr, callback);
+}
+
 static bool ReferencesSubqueryAlias(const ParsedExpression &expr, const SelectAliasMap &aliases) {
     SelectAliasMap::const_iterator alias_entry;
     if (FindSelectAliasRef(expr, aliases, alias_entry) && alias_entry->second.has_subquery) {
@@ -1274,7 +1304,7 @@ static bool ReferencesSubqueryAlias(const ParsedExpression &expr, const SelectAl
     }
 
     bool found = false;
-    ParsedExpressionIterator::EnumerateChildren(expr, [&](const ParsedExpression &child) {
+    EnumerateOrderAliasScopeChildren(expr, [&](const ParsedExpression &child) {
         if (!found && ReferencesSubqueryAlias(child, aliases)) {
             found = true;
         }
@@ -1299,7 +1329,7 @@ static bool InlineSelectAliases(unique_ptr<ParsedExpression> &expr, const Select
     }
 
     bool changed = false;
-    ParsedExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<ParsedExpression> &child) {
+    EnumerateOrderAliasScopeChildren(*expr, [&](unique_ptr<ParsedExpression> &child) {
         if (InlineSelectAliases(child, aliases)) {
             changed = true;
         }

--- a/src/yardstick_parser_ffi.cpp
+++ b/src/yardstick_parser_ffi.cpp
@@ -516,7 +516,7 @@ static void FindAggregateCalls(ParsedExpression* expr, std::vector<AggregateCall
                                const std::string& sql) {
     if (!expr) return;
 
-    switch (expr->expression_class) {
+    switch (expr->GetExpressionClass()) {
         case ExpressionClass::FUNCTION: {
             auto* func = static_cast<FunctionExpression*>(expr);
             std::string lower_name = StringUtil::Lower(func->function_name);
@@ -528,7 +528,7 @@ static void FindAggregateCalls(ParsedExpression* expr, std::vector<AggregateCall
                 if (!func->children.empty()) {
                     // First argument should be measure name (column ref or string)
                     auto* first_arg = func->children[0].get();
-                    if (first_arg->expression_class == ExpressionClass::COLUMN_REF) {
+                    if (first_arg->GetExpressionClass() == ExpressionClass::COLUMN_REF) {
                         auto* col = static_cast<ColumnRefExpression*>(first_arg);
                         info.measure_name = col->GetColumnName();
                     } else {
@@ -537,8 +537,9 @@ static void FindAggregateCalls(ParsedExpression* expr, std::vector<AggregateCall
                 }
 
                 // Get position from query_location
-                if (expr->query_location.IsValid()) {
-                    info.start_pos = static_cast<uint32_t>(expr->query_location.GetIndex());
+                auto query_location = expr->GetQueryLocation();
+                if (query_location.IsValid()) {
+                    info.start_pos = static_cast<uint32_t>(query_location.GetIndex());
                 } else {
                     info.start_pos = 0;
                 }
@@ -552,7 +553,7 @@ static void FindAggregateCalls(ParsedExpression* expr, std::vector<AggregateCall
                     auto* arg = func->children[i].get();
 
                     // Check if this is an AT modifier call
-                    if (arg->expression_class == ExpressionClass::FUNCTION) {
+                    if (arg->GetExpressionClass() == ExpressionClass::FUNCTION) {
                         auto* at_func = static_cast<FunctionExpression*>(arg);
                         std::string at_name = StringUtil::Lower(at_func->function_name);
 
@@ -746,7 +747,7 @@ static void CollectTablesFromTableRef(TableRef* ref, std::vector<YardstickTableR
 static bool ExpressionContainsAggregate(ParsedExpression* expr) {
     if (!expr) return false;
 
-    switch (expr->expression_class) {
+    switch (expr->GetExpressionClass()) {
         case ExpressionClass::FUNCTION: {
             auto* func = static_cast<FunctionExpression*>(expr);
             if (IsStandardAggregate(func->function_name)) {
@@ -818,7 +819,7 @@ static bool ExpressionContainsAggregate(ParsedExpression* expr) {
 static bool ExpressionContainsMeasureRef(ParsedExpression* expr) {
     if (!expr) return false;
 
-    switch (expr->expression_class) {
+    switch (expr->GetExpressionClass()) {
         case ExpressionClass::FUNCTION: {
             auto* func = static_cast<FunctionExpression*>(expr);
             if (StringUtil::Lower(func->function_name) == "aggregate") {
@@ -882,7 +883,7 @@ static bool ExpressionContainsMeasureRef(ParsedExpression* expr) {
 static void QualifyColumnRefs(ParsedExpression* expr, const std::string& qualifier) {
     if (!expr) return;
 
-    switch (expr->expression_class) {
+    switch (expr->GetExpressionClass()) {
         case ExpressionClass::COLUMN_REF: {
             auto* col = static_cast<ColumnRefExpression*>(expr);
             if (col->column_names.size() == 1) {
@@ -1135,10 +1136,11 @@ extern "C" YardstickSelectInfo* yardstick_parse_select(const char* sql) {
         for (auto& expr : select_node->select_list) {
             YardstickSelectItem item;
             item.expression_sql = safe_strdup(expr->ToString());
-            item.alias = expr->alias.empty() ? nullptr : safe_strdup(expr->alias);
+            item.alias = expr->HasAlias() ? safe_strdup(expr->GetAlias()) : nullptr;
 
-            if (expr->query_location.IsValid()) {
-                item.start_pos = static_cast<uint32_t>(expr->query_location.GetIndex());
+            auto query_location = expr->GetQueryLocation();
+            if (query_location.IsValid()) {
+                item.start_pos = static_cast<uint32_t>(query_location.GetIndex());
             } else {
                 item.start_pos = 0;
             }
@@ -1146,7 +1148,7 @@ extern "C" YardstickSelectInfo* yardstick_parse_select(const char* sql) {
             item.end_pos = static_cast<uint32_t>(end_pos);
 
             item.is_aggregate = ExpressionContainsAggregate(expr.get());
-            item.is_star = expr->expression_class == ExpressionClass::STAR;
+            item.is_star = expr->GetExpressionClass() == ExpressionClass::STAR;
             item.is_measure_ref = ExpressionContainsMeasureRef(expr.get());
 
             items.push_back(item);
@@ -1246,7 +1248,7 @@ using SelectAliasMap = std::unordered_map<std::string, SelectAliasEntry>;
 
 static bool FindSelectAliasRef(const ParsedExpression &expr, const SelectAliasMap &aliases,
                                SelectAliasMap::const_iterator &alias_entry) {
-    if (expr.expression_class != ExpressionClass::COLUMN_REF) {
+    if (expr.GetExpressionClass() != ExpressionClass::COLUMN_REF) {
         return false;
     }
 
@@ -1287,6 +1289,9 @@ static bool InlineSelectAliases(unique_ptr<ParsedExpression> &expr, const Select
 
     SelectAliasMap::const_iterator alias_entry;
     if (FindSelectAliasRef(*expr, aliases, alias_entry)) {
+        if (!alias_entry->second.has_subquery) {
+            return false;
+        }
         auto replacement = alias_entry->second.expression->Copy();
         replacement->ClearAlias();
         expr = std::move(replacement);
@@ -1332,11 +1337,11 @@ extern "C" char* yardstick_inline_order_by_subquery_aliases(const char* sql) {
         SelectAliasMap aliases;
         bool has_subquery_alias = false;
         for (auto& expr : select_node->select_list) {
-            if (expr->alias.empty()) {
+            if (!expr->HasAlias()) {
                 continue;
             }
             bool has_subquery = expr->HasSubquery();
-            aliases[NormalizeAliasName(expr->alias)] = SelectAliasEntry { expr.get(), has_subquery };
+            aliases[NormalizeAliasName(expr->GetAlias())] = SelectAliasEntry { expr.get(), has_subquery };
             has_subquery_alias = has_subquery_alias || has_subquery;
         }
 
@@ -1403,11 +1408,11 @@ extern "C" YardstickExpressionInfo* yardstick_parse_expression(const char* expr_
         auto& expr = expressions[0];
 
         result->sql = safe_strdup(expr->ToString());
-        result->is_identifier = expr->expression_class == ExpressionClass::COLUMN_REF;
+        result->is_identifier = expr->GetExpressionClass() == ExpressionClass::COLUMN_REF;
         result->is_aggregate = ExpressionContainsAggregate(expr.get());
 
         // If it's a simple aggregate function, extract the function name and inner expr
-        if (expr->expression_class == ExpressionClass::FUNCTION) {
+        if (expr->GetExpressionClass() == ExpressionClass::FUNCTION) {
             auto* func = static_cast<FunctionExpression*>(expr.get());
             if (IsStandardAggregate(func->function_name)) {
                 result->aggregate_func = safe_strdup(StringUtil::Upper(func->function_name));

--- a/src/yardstick_parser_ffi.cpp
+++ b/src/yardstick_parser_ffi.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 using namespace duckdb;
 
@@ -63,12 +64,21 @@ static std::string NormalizeAliasName(const std::string &alias) {
     return StringUtil::Lower(alias);
 }
 
-static bool IsPotentialOrderAliasRef(const ColumnRefExpression &colref, std::string &alias_name) {
+using TableQualifierSet = std::unordered_set<std::string>;
+
+static bool IsPotentialOrderAliasRef(
+    const ColumnRefExpression &colref,
+    const TableQualifierSet &from_qualifiers,
+    std::string &alias_name
+) {
     if (!colref.IsQualified()) {
         alias_name = colref.GetColumnName();
         return true;
     }
     if (colref.column_names.size() == 2 && StringUtil::CIEquals(colref.GetTableName(), "alias")) {
+        if (from_qualifiers.find(NormalizeAliasName(colref.GetTableName())) != from_qualifiers.end()) {
+            return false;
+        }
         alias_name = colref.GetColumnName();
         return true;
     }
@@ -1246,7 +1256,42 @@ struct SelectAliasEntry {
 
 using SelectAliasMap = std::unordered_map<std::string, SelectAliasEntry>;
 
+static void AddTableQualifier(TableQualifierSet &qualifiers, const std::string &name) {
+    if (!name.empty()) {
+        qualifiers.insert(NormalizeAliasName(name));
+    }
+}
+
+static void CollectTableQualifiers(const TableRef *ref, TableQualifierSet &qualifiers) {
+    if (!ref) {
+        return;
+    }
+
+    AddTableQualifier(qualifiers, ref->alias);
+
+    switch (ref->type) {
+        case TableReferenceType::BASE_TABLE: {
+            auto *base = static_cast<const BaseTableRef*>(ref);
+            if (ref->alias.empty()) {
+                AddTableQualifier(qualifiers, base->table_name);
+            }
+            break;
+        }
+
+        case TableReferenceType::JOIN: {
+            auto *join = static_cast<const JoinRef*>(ref);
+            CollectTableQualifiers(join->left.get(), qualifiers);
+            CollectTableQualifiers(join->right.get(), qualifiers);
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+
 static bool FindSelectAliasRef(const ParsedExpression &expr, const SelectAliasMap &aliases,
+                               const TableQualifierSet &from_qualifiers,
                                SelectAliasMap::const_iterator &alias_entry) {
     if (expr.GetExpressionClass() != ExpressionClass::COLUMN_REF) {
         return false;
@@ -1254,7 +1299,7 @@ static bool FindSelectAliasRef(const ParsedExpression &expr, const SelectAliasMa
 
     std::string alias_name;
     auto &colref = expr.Cast<ColumnRefExpression>();
-    if (!IsPotentialOrderAliasRef(colref, alias_name)) {
+    if (!IsPotentialOrderAliasRef(colref, from_qualifiers, alias_name)) {
         return false;
     }
 
@@ -1262,9 +1307,13 @@ static bool FindSelectAliasRef(const ParsedExpression &expr, const SelectAliasMa
     return alias_entry != aliases.end();
 }
 
-static bool IsSimpleSelectAliasOrder(const ParsedExpression &expr, const SelectAliasMap &aliases) {
+static bool IsSimpleSelectAliasOrder(
+    const ParsedExpression &expr,
+    const SelectAliasMap &aliases,
+    const TableQualifierSet &from_qualifiers
+) {
     SelectAliasMap::const_iterator alias_entry;
-    return FindSelectAliasRef(expr, aliases, alias_entry);
+    return FindSelectAliasRef(expr, aliases, from_qualifiers, alias_entry);
 }
 
 static void EnumerateOrderAliasScopeChildren(
@@ -1297,28 +1346,36 @@ static void EnumerateOrderAliasScopeChildren(
     ParsedExpressionIterator::EnumerateChildren(expr, callback);
 }
 
-static bool ReferencesSubqueryAlias(const ParsedExpression &expr, const SelectAliasMap &aliases) {
+static bool ReferencesSubqueryAlias(
+    const ParsedExpression &expr,
+    const SelectAliasMap &aliases,
+    const TableQualifierSet &from_qualifiers
+) {
     SelectAliasMap::const_iterator alias_entry;
-    if (FindSelectAliasRef(expr, aliases, alias_entry) && alias_entry->second.has_subquery) {
+    if (FindSelectAliasRef(expr, aliases, from_qualifiers, alias_entry) && alias_entry->second.has_subquery) {
         return true;
     }
 
     bool found = false;
     EnumerateOrderAliasScopeChildren(expr, [&](const ParsedExpression &child) {
-        if (!found && ReferencesSubqueryAlias(child, aliases)) {
+        if (!found && ReferencesSubqueryAlias(child, aliases, from_qualifiers)) {
             found = true;
         }
     });
     return found;
 }
 
-static bool InlineSelectAliases(unique_ptr<ParsedExpression> &expr, const SelectAliasMap &aliases) {
+static bool InlineSelectAliases(
+    unique_ptr<ParsedExpression> &expr,
+    const SelectAliasMap &aliases,
+    const TableQualifierSet &from_qualifiers
+) {
     if (!expr) {
         return false;
     }
 
     SelectAliasMap::const_iterator alias_entry;
-    if (FindSelectAliasRef(*expr, aliases, alias_entry)) {
+    if (FindSelectAliasRef(*expr, aliases, from_qualifiers, alias_entry)) {
         if (!alias_entry->second.has_subquery) {
             return false;
         }
@@ -1330,7 +1387,7 @@ static bool InlineSelectAliases(unique_ptr<ParsedExpression> &expr, const Select
 
     bool changed = false;
     EnumerateOrderAliasScopeChildren(*expr, [&](unique_ptr<ParsedExpression> &child) {
-        if (InlineSelectAliases(child, aliases)) {
+        if (InlineSelectAliases(child, aliases, from_qualifiers)) {
             changed = true;
         }
     });
@@ -1364,6 +1421,9 @@ extern "C" char* yardstick_inline_order_by_subquery_aliases(const char* sql) {
         }
 
         auto* select_node = static_cast<SelectNode*>(select_stmt->node.get());
+        TableQualifierSet from_qualifiers;
+        CollectTableQualifiers(select_node->from_table.get(), from_qualifiers);
+
         SelectAliasMap aliases;
         bool has_subquery_alias = false;
         for (auto& expr : select_node->select_list) {
@@ -1390,13 +1450,13 @@ extern "C" char* yardstick_inline_order_by_subquery_aliases(const char* sql) {
                 if (!order.expression) {
                     continue;
                 }
-                if (IsSimpleSelectAliasOrder(*order.expression, aliases)) {
+                if (IsSimpleSelectAliasOrder(*order.expression, aliases, from_qualifiers)) {
                     continue;
                 }
-                if (!ReferencesSubqueryAlias(*order.expression, aliases)) {
+                if (!ReferencesSubqueryAlias(*order.expression, aliases, from_qualifiers)) {
                     continue;
                 }
-                changed = InlineSelectAliases(order.expression, aliases) || changed;
+                changed = InlineSelectAliases(order.expression, aliases, from_qualifiers) || changed;
             }
         }
 

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -1771,3 +1771,46 @@ FROM sales_v
 WHERE year = 2023;
 ----
 150.0
+
+# ORDER BY with named aggregate that expands to a subquery (GH #28)
+query IIRR
+SEMANTIC SELECT
+    year,
+    region,
+    AGGREGATE(revenue) AS revenue,
+    AGGREGATE(revenue) AT (ALL region) AS year_total
+FROM sales_v
+ORDER BY revenue/year_total, year, region;
+----
+2022	EU	50.0	150.0
+2023	EU	75.0	225.0
+2022	US	100.0	150.0
+2023	US	150.0	225.0
+
+# ORDER BY with simple alias of subquery expression (GH #28)
+query IIR
+SEMANTIC SELECT
+    year,
+    region,
+    AGGREGATE(revenue) AT (ALL region) AS year_total
+FROM sales_v
+ORDER BY year_total, year, region;
+----
+2022	EU	150.0
+2022	US	150.0
+2023	EU	225.0
+2023	US	225.0
+
+# ORDER BY DESC with subquery alias (GH #28)
+query IIR
+SEMANTIC SELECT
+    year,
+    region,
+    AGGREGATE(revenue) AT (ALL region) AS year_total
+FROM sales_v
+ORDER BY year_total DESC, year, region;
+----
+2023	EU	225.0
+2023	US	225.0
+2022	EU	150.0
+2022	US	150.0

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -190,6 +190,7 @@ SEMANTIC SELECT
     alias.year_total AS dim_total,
     AGGREGATE(revenue) AT (ALL bucket) AS year_total
 FROM alias_collision_v alias
+GROUP BY alias.bucket, alias.year_total
 ORDER BY alias.year_total + 1;
 ----
 2	1	20.0

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -192,6 +192,50 @@ WHERE prev_r IS NOT NULL AND r < prev_r;
 ----
 0
 
+# ORDER BY scalar subquery scopes should not be searched for outer aliases (#28)
+statement ok
+CREATE TABLE order_subquery_totals(year INT, total DOUBLE);
+
+statement ok
+INSERT INTO order_subquery_totals VALUES (2022, 2), (2023, 1);
+
+query IIR
+SEMANTIC SELECT
+    o.year,
+    o.region,
+    AGGREGATE(revenue) AT (ALL region) AS total
+FROM sales_v o
+ORDER BY (
+    SELECT total
+    FROM order_subquery_totals st
+    WHERE st.year = o.year
+), o.region;
+----
+2023	EU	225.0
+2023	US	225.0
+2022	EU	150.0
+2022	US	150.0
+
+# The outer side of IN/ANY still belongs to the ORDER BY alias scope (#28)
+statement ok
+CREATE TABLE order_allowed_totals(total DOUBLE);
+
+statement ok
+INSERT INTO order_allowed_totals VALUES (225);
+
+query IIR
+SEMANTIC SELECT
+    o.year,
+    o.region,
+    AGGREGATE(revenue) AT (ALL region) AS total
+FROM sales_v o
+ORDER BY total IN (SELECT total FROM order_allowed_totals), o.region, o.year;
+----
+2022	EU	150.0
+2022	US	150.0
+2023	EU	225.0
+2023	US	225.0
+
 # Lowercase from with line break
 query IIR rowsort
 SEMANTIC SELECT year, region, AGGREGATE(revenue) AT (ALL region) AS year_total

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -184,17 +184,16 @@ CREATE VIEW alias_collision_v AS
 SELECT bucket, year_total, SUM(amount) AS MEASURE revenue
 FROM alias_collision_sales;
 
-query IIR
+query IR
 SEMANTIC SELECT
     alias.bucket,
-    alias.year_total AS dim_total,
     AGGREGATE(revenue) AT (ALL bucket) AS year_total
 FROM alias_collision_v alias
 GROUP BY alias.bucket, alias.year_total
 ORDER BY alias.year_total + 1;
 ----
-2	1	20.0
-1	2	10.0
+2	20.0
+1	10.0
 
 # Non-subquery aliases in mixed ORDER BY expressions should stay alias refs (#28)
 statement ok

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -114,6 +114,50 @@ FROM sales_v;
 2023	EU	225.0
 2023	US	225.0
 
+# ORDER BY expression referencing a named aggregate that expands to a subquery (#28)
+query IIRR
+SEMANTIC SELECT
+    year,
+    region,
+    AGGREGATE(revenue) AS revenue,
+    AGGREGATE(revenue) AT (ALL region) AS year_total
+FROM sales_v
+ORDER BY revenue/year_total, year, region;
+----
+2022	EU	50.0	150.0
+2023	EU	75.0	225.0
+2022	US	100.0	150.0
+2023	US	150.0	225.0
+
+# Qualified ORDER BY tie-breakers should remain in the original query scope (#28)
+query IIRR
+SEMANTIC SELECT
+    o.year,
+    o.region,
+    AGGREGATE(revenue) AS revenue,
+    AGGREGATE(revenue) AT (ALL region) AS year_total
+FROM sales_v o
+ORDER BY revenue/year_total, o.region, o.year;
+----
+2022	EU	50.0	150.0
+2023	EU	75.0	225.0
+2022	US	100.0	150.0
+2023	US	150.0	225.0
+
+# Simple subquery aliases in ORDER BY should not force query wrapping (#28)
+query IIR
+SEMANTIC SELECT
+    o.year,
+    o.region,
+    AGGREGATE(revenue) AT (ALL region) AS year_total
+FROM sales_v o
+ORDER BY year_total, o.region, o.year;
+----
+2022	EU	150.0
+2022	US	150.0
+2023	EU	225.0
+2023	US	225.0
+
 # Lowercase from with line break
 query IIR rowsort
 SEMANTIC SELECT year, region, AGGREGATE(revenue) AT (ALL region) AS year_total

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -188,7 +188,7 @@ query IIR
 SEMANTIC SELECT
     alias.bucket,
     alias.year_total AS dim_total,
-    AGGREGATE(revenue) AT (ALL year_total) AS year_total
+    AGGREGATE(revenue) AT (ALL bucket) AS year_total
 FROM alias_collision_v alias
 ORDER BY alias.year_total + 1;
 ----

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -190,7 +190,7 @@ SEMANTIC SELECT
     AGGREGATE(revenue) AT (ALL bucket) AS year_total
 FROM alias_collision_v alias
 GROUP BY alias.bucket, alias.year_total
-ORDER BY alias.year_total + 1;
+ORDER BY ANY_VALUE(alias.year_total) + 1;
 ----
 2	20.0
 1	10.0

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -158,6 +158,40 @@ ORDER BY year_total, o.region, o.year;
 2023	EU	225.0
 2023	US	225.0
 
+# Non-subquery aliases in mixed ORDER BY expressions should stay alias refs (#28)
+statement ok
+CREATE TABLE order_alias_rows AS
+SELECT i::INT AS id, 1.0 AS amount
+FROM range(32) t(i);
+
+statement ok
+CREATE VIEW order_alias_v AS
+SELECT id, SUM(amount) AS MEASURE revenue
+FROM order_alias_rows;
+
+query I
+SELECT setseed(0.42);
+----
+NULL
+
+query I
+SEMANTIC WITH q AS (
+    SELECT
+        random() AS r,
+        id,
+        AGGREGATE(revenue) AT (ALL id) AS all_revenue
+    FROM order_alias_v
+    ORDER BY r / all_revenue
+)
+SELECT COUNT(*)::INTEGER
+FROM (
+    SELECT r, LAG(r) OVER () AS prev_r
+    FROM q
+)
+WHERE prev_r IS NOT NULL AND r < prev_r;
+----
+0
+
 # Lowercase from with line break
 query IIR rowsort
 SEMANTIC SELECT year, region, AGGREGATE(revenue) AT (ALL region) AS year_total

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -158,6 +158,43 @@ ORDER BY year_total, o.region, o.year;
 2023	EU	225.0
 2023	US	225.0
 
+# DuckDB's alias namespace should still work when no table qualifier shadows it (#28)
+query IIR
+SEMANTIC SELECT
+    o.year,
+    o.region,
+    AGGREGATE(revenue) AT (ALL region) AS year_total
+FROM sales_v o
+ORDER BY alias.year_total + 1, o.region, o.year;
+----
+2022	EU	150.0
+2022	US	150.0
+2023	EU	225.0
+2023	US	225.0
+
+# A real table qualifier named alias should not be treated as the alias namespace (#28)
+statement ok
+CREATE TABLE alias_collision_sales(bucket INT, year_total INT, amount DOUBLE);
+
+statement ok
+INSERT INTO alias_collision_sales VALUES (1, 2, 10), (2, 1, 20);
+
+statement ok
+CREATE VIEW alias_collision_v AS
+SELECT bucket, year_total, SUM(amount) AS MEASURE revenue
+FROM alias_collision_sales;
+
+query IIR
+SEMANTIC SELECT
+    alias.bucket,
+    alias.year_total AS dim_total,
+    AGGREGATE(revenue) AT (ALL year_total) AS year_total
+FROM alias_collision_v alias
+ORDER BY alias.year_total + 1;
+----
+2	1	20.0
+1	2	10.0
+
 # Non-subquery aliases in mixed ORDER BY expressions should stay alias refs (#28)
 statement ok
 CREATE TABLE order_alias_rows AS

--- a/yardstick-rs/src/parser_ffi.rs
+++ b/yardstick-rs/src/parser_ffi.rs
@@ -169,6 +169,7 @@ type FnFreeCreateViewInfo = unsafe extern "C" fn(*mut YardstickCreateViewInfo);
 type FnReplaceRange = unsafe extern "C" fn(*const c_char, u32, u32, *const c_char) -> *mut c_char;
 type FnApplyReplacements = unsafe extern "C" fn(*const c_char, *const YardstickReplacement, usize) -> *mut c_char;
 type FnQualifyExpression = unsafe extern "C" fn(*const c_char, *const c_char) -> *mut c_char;
+type FnInlineOrderBySubqueryAliases = unsafe extern "C" fn(*const c_char) -> *mut c_char;
 type FnFreeString = unsafe extern "C" fn(*mut c_char);
 type FnExpandAggregateCall = unsafe extern "C" fn(
     *const c_char, *const c_char, *const YardstickAtModifier, usize,
@@ -187,6 +188,7 @@ static FN_FREE_CREATE_VIEW_INFO: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut())
 static FN_REPLACE_RANGE: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static FN_APPLY_REPLACEMENTS: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static FN_QUALIFY_EXPRESSION: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
+static FN_INLINE_ORDER_BY_SUBQUERY_ALIASES: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static FN_FREE_STRING: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 static FN_EXPAND_AGGREGATE_CALL: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 
@@ -204,6 +206,7 @@ pub extern "C" fn yardstick_init_parser_ffi(
     replace_range: FnReplaceRange,
     apply_replacements: FnApplyReplacements,
     qualify_expression: FnQualifyExpression,
+    inline_order_by_subquery_aliases: FnInlineOrderBySubqueryAliases,
     free_string: FnFreeString,
     expand_aggregate_call: FnExpandAggregateCall,
 ) {
@@ -218,6 +221,7 @@ pub extern "C" fn yardstick_init_parser_ffi(
     FN_REPLACE_RANGE.store(replace_range as *mut (), Ordering::SeqCst);
     FN_APPLY_REPLACEMENTS.store(apply_replacements as *mut (), Ordering::SeqCst);
     FN_QUALIFY_EXPRESSION.store(qualify_expression as *mut (), Ordering::SeqCst);
+    FN_INLINE_ORDER_BY_SUBQUERY_ALIASES.store(inline_order_by_subquery_aliases as *mut (), Ordering::SeqCst);
     FN_FREE_STRING.store(free_string as *mut (), Ordering::SeqCst);
     FN_EXPAND_AGGREGATE_CALL.store(expand_aggregate_call as *mut (), Ordering::SeqCst);
 }
@@ -276,6 +280,10 @@ unsafe fn yardstick_apply_replacements(sql: *const c_char, replacements: *const 
 
 unsafe fn yardstick_free_string(ptr: *mut c_char) {
     call_ffi!(FN_FREE_STRING, FnFreeString, ptr)
+}
+
+unsafe fn yardstick_inline_order_by_subquery_aliases(sql: *const c_char) -> *mut c_char {
+    call_ffi!(FN_INLINE_ORDER_BY_SUBQUERY_ALIASES, FnInlineOrderBySubqueryAliases, sql)
 }
 
 unsafe fn yardstick_expand_aggregate_call(
@@ -812,6 +820,25 @@ pub fn qualify_expression(expr: &str, qualifier: &str) -> Result<String, String>
         let result = c_str_to_string(result_ptr).unwrap_or_default();
         yardstick_free_string(result_ptr);
         Ok(result)
+    }
+}
+
+pub fn inline_order_by_subquery_aliases(sql: &str) -> Option<String> {
+    let fn_ptr = FN_INLINE_ORDER_BY_SUBQUERY_ALIASES.load(Ordering::SeqCst);
+    if fn_ptr.is_null() {
+        return None;
+    }
+
+    let c_sql = CString::new(sql).ok()?;
+    unsafe {
+        let result_ptr = yardstick_inline_order_by_subquery_aliases(c_sql.as_ptr());
+        if result_ptr.is_null() {
+            return None;
+        }
+
+        let result = c_str_to_string(result_ptr).unwrap_or_default();
+        yardstick_free_string(result_ptr);
+        Some(result)
     }
 }
 

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5504,6 +5504,23 @@ fn extract_subquery_aliases_from_select(sql: &str) -> Vec<String> {
                     }
                 }
             }
+            b'-' if i + 1 < select_text.len() && bytes[i + 1] == b'-' => {
+                while i < select_text.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if i + 1 < select_text.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < select_text.len() {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
             b',' if depth == 0 => {
                 if let Some(alias) = subquery_alias_from_item(&select_text[item_start..i]) {
                     aliases.push(alias);

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5522,9 +5522,32 @@ fn extract_subquery_aliases_from_select(sql: &str) -> Vec<String> {
     aliases
 }
 
+/// Check if text contains a parenthesized subquery: `(SELECT ...)` or `(WITH ... SELECT ...)`,
+/// tolerating whitespace between `(` and the keyword.
+fn item_has_subquery(item: &str) -> bool {
+    let bytes = item.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'(' {
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j + 6 <= bytes.len() && bytes[j..j + 6].eq_ignore_ascii_case(b"SELECT") {
+                return true;
+            }
+            if j + 4 <= bytes.len() && bytes[j..j + 4].eq_ignore_ascii_case(b"WITH") {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Check if a single SELECT item contains a `(SELECT ...)` subquery and has an AS alias.
 fn subquery_alias_from_item(item: &str) -> Option<String> {
-    if !item.to_uppercase().contains("(SELECT ") {
+    if !item_has_subquery(item) {
         return None;
     }
     // Find the last top-level whitespace-AS-whitespace (not inside parentheses).
@@ -5577,35 +5600,48 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
     }
 }
 
-/// Check if an identifier appears as a whole word in text (case-insensitive),
-/// skipping string literals and comments.
+/// Check if an identifier appears as a top-level whole word in text (case-insensitive),
+/// skipping string literals, comments, and content inside parentheses.
 fn identifier_appears_in(text: &str, ident: &str) -> bool {
-    // Strip string literals and comments before scanning for the identifier.
     let stripped = strip_literals_and_comments(text);
     let stripped_upper = stripped.to_uppercase();
     let ident_upper = ident.to_uppercase();
+
+    // Pre-compute parenthesis depth at each byte position
+    let bytes = stripped.as_bytes();
+    let mut depths = vec![0i32; bytes.len()];
+    let mut depth: i32 = 0;
+    for i in 0..bytes.len() {
+        if bytes[i] == b'(' {
+            depth += 1;
+        }
+        depths[i] = depth;
+        if bytes[i] == b')' {
+            depth -= 1;
+        }
+    }
+
     let mut search_from = 0;
     while let Some(pos) = stripped_upper[search_from..].find(&ident_upper) {
         let abs = search_from + pos;
+        // Only match at top level (outside parentheses)
+        let at_top_level = depths[abs] == 0;
         let before_ok = abs == 0 || {
-            let c = stripped.as_bytes()[abs - 1];
+            let c = bytes[abs - 1];
             if c == b'"' || c == b'`' {
-                // Bare quoted identifier like "year_total" is OK;
-                // qualified like o."year_total" (dot before quote) is not.
-                abs < 2 || stripped.as_bytes()[abs - 2] != b'.'
+                abs < 2 || bytes[abs - 2] != b'.'
             } else {
                 !c.is_ascii_alphanumeric() && c != b'_' && c != b'.'
             }
         };
         let after_pos = abs + ident_upper.len();
         let after_ok = after_pos >= stripped_upper.len() || {
-            let c = stripped.as_bytes()[after_pos];
+            let c = bytes[after_pos];
             !c.is_ascii_alphanumeric() && c != b'_'
         };
-        if before_ok && after_ok {
+        if at_top_level && before_ok && after_ok {
             return true;
         }
-        // Advance past the current match start, staying on a char boundary
         search_from = abs + 1;
         while search_from < stripped_upper.len()
             && !stripped_upper.is_char_boundary(search_from)
@@ -8207,6 +8243,11 @@ GROUP BY s.year";
         // But bare quoted aliases like "year_total" should match
         assert!(identifier_appears_in(r#""year_total""#, "year_total"));
         assert!(identifier_appears_in(r#"`year_total`"#, "year_total"));
+        // Should not match inside parentheses (e.g., function arguments)
+        assert!(!identifier_appears_in("EXTRACT(YEAR FROM o.ts)", "year"));
+        assert!(!identifier_appears_in("COALESCE(year_total, 0)", "year_total"));
+        // But top-level references should still match
+        assert!(identifier_appears_in("year_total + COALESCE(x, 0)", "year_total"));
     }
 
     #[test]
@@ -8235,6 +8276,15 @@ GROUP BY s.year";
         assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
         // Multiple spaces
         let item = " (SELECT 1)  AS  year_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
+        // Space after opening paren: ( SELECT ...)
+        let item = " ( SELECT 1) AS year_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
+        // Newline after opening paren
+        let item = " (\nSELECT 1) AS year_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
+        // CTE subquery: (WITH ... SELECT ...)
+        let item = " (WITH cte AS (SELECT 1) SELECT * FROM cte) AS year_total";
         assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
     }
 

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5734,7 +5734,12 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
         let before_ok = abs == 0 || {
             let c = bytes[abs - 1];
             if c == b'"' || c == b'`' {
-                abs < 2 || bytes[abs - 2] != b'.'
+                // Scan backwards past whitespace to check for a dot (e.g. o . "alias")
+                let mut k = abs.saturating_sub(2);
+                while k > 0 && bytes[k].is_ascii_whitespace() {
+                    k -= 1;
+                }
+                abs < 2 || bytes[k] != b'.'
             } else {
                 !c.is_ascii_alphanumeric() && c != b'_' && c != b'.'
             }
@@ -8397,6 +8402,9 @@ GROUP BY s.year";
         // Should not match qualified quoted names like o."year_total"
         assert!(!identifier_appears_in(r#"o."year_total""#, "year_total"));
         assert!(!identifier_appears_in(r#"o.`year_total`"#, "year_total"));
+        // Should not match spaced qualified quoted names like o . "year_total"
+        assert!(!identifier_appears_in(r#"o . "year_total""#, "year_total"));
+        assert!(!identifier_appears_in(r#"o .  `year_total`"#, "year_total"));
         // But bare quoted aliases like "year_total" should match
         assert!(identifier_appears_in(r#""year_total""#, "year_total"));
         assert!(identifier_appears_in(r#"`year_total`"#, "year_total"));

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5758,15 +5758,24 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
         let abs = search_from + pos;
         let before_ok = abs == 0 || {
             let c = bytes[abs - 1];
-            if c == b'"' || c == b'`' {
+            if c == b'.' {
+                false // directly after dot = qualified
+            } else if c == b'"' || c == b'`' {
                 // Scan backwards past whitespace to check for a dot (e.g. o . "alias")
                 let mut k = abs.saturating_sub(2);
                 while k > 0 && bytes[k].is_ascii_whitespace() {
                     k -= 1;
                 }
                 abs < 2 || bytes[k] != b'.'
+            } else if c.is_ascii_whitespace() {
+                // Scan backwards past whitespace to check for a dot (e.g. o . year_total)
+                let mut k = abs - 1;
+                while k > 0 && bytes[k].is_ascii_whitespace() {
+                    k -= 1;
+                }
+                bytes[k] != b'.'
             } else {
-                !c.is_ascii_alphanumeric() && c != b'_' && c != b'.'
+                !c.is_ascii_alphanumeric() && c != b'_'
             }
         };
         let after_pos = abs + ident_upper.len();
@@ -5866,6 +5875,26 @@ fn strip_nested_subqueries(text: &str) -> String {
                 i += 1;
                 while i < bytes.len() && depth > 0 {
                     match bytes[i] {
+                        b'\'' => {
+                            out[i] = b' ';
+                            i += 1;
+                            while i < bytes.len() {
+                                if bytes[i] == b'\'' {
+                                    out[i] = b' ';
+                                    if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                                        out[i + 1] = b' ';
+                                        i += 2;
+                                    } else {
+                                        i += 1;
+                                        break;
+                                    }
+                                } else {
+                                    out[i] = b' ';
+                                    i += 1;
+                                }
+                            }
+                            continue;
+                        }
                         b'(' => depth += 1,
                         b')' => depth -= 1,
                         _ => {}
@@ -8430,6 +8459,9 @@ GROUP BY s.year";
         // Should not match spaced qualified quoted names like o . "year_total"
         assert!(!identifier_appears_in(r#"o . "year_total""#, "year_total"));
         assert!(!identifier_appears_in(r#"o .  `year_total`"#, "year_total"));
+        // Should not match spaced qualified unquoted names like o . year_total
+        assert!(!identifier_appears_in("o . year_total", "year_total"));
+        assert!(!identifier_appears_in("o .  year_total", "year_total"));
         // But bare quoted aliases like "year_total" should match
         assert!(identifier_appears_in(r#""year_total""#, "year_total"));
         assert!(identifier_appears_in(r#"`year_total`"#, "year_total"));

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5722,12 +5722,14 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
 fn identifier_appears_in(text: &str, ident: &str) -> bool {
     let stripped = strip_literals_and_comments(text);
     let cleaned = strip_nested_subqueries(&stripped);
-    let stripped_upper = cleaned.to_uppercase();
+    // Perform all searching and boundary checks on the uppercased string
+    // to avoid byte-offset mismatches between the original and uppercased forms.
+    let upper = cleaned.to_uppercase();
     let ident_upper = ident.to_uppercase();
-    let bytes = cleaned.as_bytes();
+    let bytes = upper.as_bytes();
 
     let mut search_from = 0;
-    while let Some(pos) = stripped_upper[search_from..].find(&ident_upper) {
+    while let Some(pos) = upper[search_from..].find(&ident_upper) {
         let abs = search_from + pos;
         let before_ok = abs == 0 || {
             let c = bytes[abs - 1];
@@ -5738,7 +5740,7 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
             }
         };
         let after_pos = abs + ident_upper.len();
-        let after_ok = after_pos >= stripped_upper.len() || {
+        let after_ok = after_pos >= bytes.len() || {
             let c = bytes[after_pos];
             !c.is_ascii_alphanumeric() && c != b'_'
         };
@@ -5746,9 +5748,7 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
             return true;
         }
         search_from = abs + 1;
-        while search_from < stripped_upper.len()
-            && !stripped_upper.is_char_boundary(search_from)
-        {
+        while search_from < bytes.len() && !upper.is_char_boundary(search_from) {
             search_from += 1;
         }
     }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5527,27 +5527,42 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
     if !item.to_uppercase().contains("(SELECT ") {
         return None;
     }
-    // Find the last top-level " AS " (not inside parentheses).
-    // Compare directly on `item` using case-insensitive matching to avoid
-    // byte-offset mismatches between `item` and its uppercase form.
+    // Find the last top-level whitespace-AS-whitespace (not inside parentheses).
+    // Handles spaces, tabs, and newlines around AS.
+    let bytes = item.as_bytes();
     let mut depth: i32 = 0;
-    let mut last_as_pos: Option<usize> = None;
-    for (i, ch) in item.char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => depth -= 1,
-            ' ' if depth == 0 => {
-                if item[i..].len() >= 4
-                    && item[i..].as_bytes()[1..4].eq_ignore_ascii_case(b"AS ")
-                {
-                    last_as_pos = Some(i + 4);
+    let mut last_as_end: Option<usize> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            c if depth == 0 && c.is_ascii_whitespace() => {
+                // Skip leading whitespace
+                let ws_start = i;
+                while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                    i += 1;
                 }
+                // Check for "AS" followed by whitespace
+                if i + 2 <= bytes.len()
+                    && bytes[i..i + 2].eq_ignore_ascii_case(b"AS")
+                    && (i + 2 >= bytes.len() || bytes[i + 2].is_ascii_whitespace())
+                {
+                    let _ = ws_start;
+                    let mut end = i + 2;
+                    while end < bytes.len() && bytes[end].is_ascii_whitespace() {
+                        end += 1;
+                    }
+                    last_as_end = Some(end);
+                }
+                continue; // already advanced i past whitespace
             }
             _ => {}
         }
+        i += 1;
     }
-    let as_pos = last_as_pos?;
-    let alias = item[as_pos..].trim();
+    let as_end = last_as_end?;
+    let alias = item[as_end..].trim();
     // Extract identifier: alphanumeric, underscore, or quoted
     let alias = alias
         .split(|c: char| !c.is_alphanumeric() && c != '_' && c != '"' && c != '`')
@@ -5590,7 +5605,13 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
         if before_ok && after_ok {
             return true;
         }
+        // Advance past the current match start, staying on a char boundary
         search_from = abs + 1;
+        while search_from < stripped_upper.len()
+            && !stripped_upper.is_char_boundary(search_from)
+        {
+            search_from += 1;
+        }
     }
     false
 }
@@ -8202,6 +8223,19 @@ GROUP BY s.year";
         let item = " (SELECT 1) || '\u{00e9}' AS year_total";
         let alias = subquery_alias_from_item(item);
         assert_eq!(alias, Some("year_total".to_string()));
+    }
+
+    #[test]
+    fn test_subquery_alias_from_item_whitespace_variants() {
+        // Tab between AS and alias
+        let item = " (SELECT 1) AS\tyear_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
+        // Newline between AS and alias
+        let item = " (SELECT 1) AS\nyear_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
+        // Multiple spaces
+        let item = " (SELECT 1)  AS  year_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5528,25 +5528,60 @@ fn item_has_subquery(item: &str) -> bool {
     let bytes = item.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'(' {
-            let mut j = i + 1;
-            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-                j += 1;
+        match bytes[i] {
+            b'\'' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
             }
-            if j + 6 <= bytes.len()
-                && bytes[j..j + 6].eq_ignore_ascii_case(b"SELECT")
-                && (j + 6 >= bytes.len() || !bytes[j + 6].is_ascii_alphanumeric() && bytes[j + 6] != b'_')
-            {
-                return true;
+            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
             }
-            if j + 4 <= bytes.len()
-                && bytes[j..j + 4].eq_ignore_ascii_case(b"WITH")
-                && (j + 4 >= bytes.len() || !bytes[j + 4].is_ascii_alphanumeric() && bytes[j + 4] != b'_')
-            {
-                return true;
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
             }
+            b'(' => {
+                let mut j = i + 1;
+                while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                if j + 6 <= bytes.len()
+                    && bytes[j..j + 6].eq_ignore_ascii_case(b"SELECT")
+                    && (j + 6 >= bytes.len()
+                        || !bytes[j + 6].is_ascii_alphanumeric() && bytes[j + 6] != b'_')
+                {
+                    return true;
+                }
+                if j + 4 <= bytes.len()
+                    && bytes[j..j + 4].eq_ignore_ascii_case(b"WITH")
+                    && (j + 4 >= bytes.len()
+                        || !bytes[j + 4].is_ascii_alphanumeric() && bytes[j + 4] != b'_')
+                {
+                    return true;
+                }
+                i += 1;
+            }
+            _ => i += 1,
         }
-        i += 1;
     }
     false
 }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5603,6 +5603,28 @@ fn item_has_subquery(item: &str) -> bool {
     false
 }
 
+/// Check if position `pos` in `text` starts a SQL keyword (followed by a non-identifier char).
+fn is_sql_keyword_at(text: &str, pos: usize) -> bool {
+    const KEYWORDS: &[&[u8]] = &[
+        b"IS", b"IN", b"OR", b"ON", b"AND", b"NOT", b"THEN", b"ELSE", b"END",
+        b"WHEN", b"LIKE", b"BETWEEN", b"FROM", b"WHERE", b"GROUP", b"ORDER",
+        b"HAVING", b"LIMIT", b"OFFSET", b"UNION", b"EXCEPT", b"INTERSECT",
+        b"JOIN", b"LEFT", b"RIGHT", b"INNER", b"OUTER", b"CROSS", b"FULL",
+        b"NULL", b"TRUE", b"FALSE", b"CASE", b"CAST", b"OVER", b"ASC", b"DESC",
+    ];
+    let bytes = text.as_bytes();
+    for kw in KEYWORDS {
+        let end = pos + kw.len();
+        if end <= bytes.len()
+            && bytes[pos..end].eq_ignore_ascii_case(kw)
+            && (end >= bytes.len() || !bytes[end].is_ascii_alphanumeric() && bytes[end] != b'_')
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Check if a single SELECT item contains a `(SELECT ...)` subquery and has an alias.
 /// Supports both explicit (`AS alias`) and implicit (`(SELECT ...) alias`) forms.
 fn subquery_alias_from_item(item: &str) -> Option<String> {
@@ -5670,11 +5692,14 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
                                 end += 1;
                             }
                             last_alias_start = Some(end);
-                        } else if bytes[j].is_ascii_alphabetic() || bytes[j] == b'_'
-                            || bytes[j] == b'"' || bytes[j] == b'`'
-                        {
-                            // Implicit alias (no AS keyword)
+                        } else if bytes[j] == b'"' || bytes[j] == b'`' {
+                            // Quoted implicit alias
                             last_alias_start = Some(j);
+                        } else if bytes[j].is_ascii_alphabetic() || bytes[j] == b'_' {
+                            // Unquoted implicit alias: exclude SQL keywords that can follow a subquery
+                            if !is_sql_keyword_at(item, j) {
+                                last_alias_start = Some(j);
+                            }
                         }
                     }
                 }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5716,13 +5716,15 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
 }
 
 /// Check if an identifier appears as a whole word in text (case-insensitive),
-/// skipping string literals and comments. Matches at any parenthesis depth
-/// so that `COALESCE(year_total, 0)` still triggers wrapping.
+/// skipping string literals, comments, and nested subqueries.
+/// Matches inside regular function calls (e.g. `COALESCE(year_total, 0)`)
+/// but not inside `(SELECT ...)` subquery scopes.
 fn identifier_appears_in(text: &str, ident: &str) -> bool {
     let stripped = strip_literals_and_comments(text);
-    let stripped_upper = stripped.to_uppercase();
+    let cleaned = strip_nested_subqueries(&stripped);
+    let stripped_upper = cleaned.to_uppercase();
     let ident_upper = ident.to_uppercase();
-    let bytes = stripped.as_bytes();
+    let bytes = cleaned.as_bytes();
 
     let mut search_from = 0;
     while let Some(pos) = stripped_upper[search_from..].find(&ident_upper) {
@@ -5803,6 +5805,48 @@ fn strip_literals_and_comments(text: &str) -> String {
             }
             _ => i += 1,
         }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| text.to_string())
+}
+
+/// Replace content inside `(SELECT ...)` and `(WITH ...)` subquery blocks with spaces.
+/// Regular function-call parentheses are left intact.
+fn strip_nested_subqueries(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out = text.to_string().into_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'(' {
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            let is_subquery = (j + 6 <= bytes.len()
+                && bytes[j..j + 6].eq_ignore_ascii_case(b"SELECT")
+                && (j + 6 >= bytes.len()
+                    || !bytes[j + 6].is_ascii_alphanumeric() && bytes[j + 6] != b'_'))
+                || (j + 4 <= bytes.len()
+                    && bytes[j..j + 4].eq_ignore_ascii_case(b"WITH")
+                    && (j + 4 >= bytes.len()
+                        || !bytes[j + 4].is_ascii_alphanumeric() && bytes[j + 4] != b'_'));
+            if is_subquery {
+                // Blank out everything from ( to matching )
+                let mut depth = 1;
+                out[i] = b' ';
+                i += 1;
+                while i < bytes.len() && depth > 0 {
+                    match bytes[i] {
+                        b'(' => depth += 1,
+                        b')' => depth -= 1,
+                        _ => {}
+                    }
+                    out[i] = b' ';
+                    i += 1;
+                }
+                continue;
+            }
+        }
+        i += 1;
     }
     String::from_utf8(out).unwrap_or_else(|_| text.to_string())
 }
@@ -8344,11 +8388,14 @@ GROUP BY s.year";
         // But bare quoted aliases like "year_total" should match
         assert!(identifier_appears_in(r#""year_total""#, "year_total"));
         assert!(identifier_appears_in(r#"`year_total`"#, "year_total"));
-        // Should match inside parentheses (e.g., COALESCE(year_total, 0))
+        // Should match inside regular function call parentheses
         assert!(identifier_appears_in("COALESCE(year_total, 0)", "year_total"));
         assert!(identifier_appears_in("(year_total)", "year_total"));
         // Top-level references should still match
         assert!(identifier_appears_in("year_total + COALESCE(x, 0)", "year_total"));
+        // Should NOT match inside nested subqueries
+        assert!(!identifier_appears_in("(SELECT year_total FROM aux)", "year_total"));
+        assert!(!identifier_appears_in("(SELECT year_total FROM aux), o.col", "year_total"));
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5167,6 +5167,118 @@ fn validate_set_expression_requirements(
     None
 }
 
+/// Extract alias names of SELECT items whose expressions contain subqueries.
+fn extract_subquery_aliases_from_select(sql: &str) -> Vec<String> {
+    let from_pos = find_top_level_keyword(sql, "FROM", 0).unwrap_or(sql.len());
+    let upper = sql.to_uppercase();
+    let select_start = upper.find("SELECT").map(|p| p + 6).unwrap_or(0);
+    let select_text = &sql[select_start..from_pos];
+
+    let mut aliases = Vec::new();
+    let bytes = select_text.as_bytes();
+    let mut depth: i32 = 0;
+    let mut item_start = 0;
+
+    for i in 0..select_text.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b'\'' => {
+                // Skip single-quoted strings
+                let mut j = i + 1;
+                while j < select_text.len() {
+                    if bytes[j] == b'\'' {
+                        if j + 1 < select_text.len() && bytes[j + 1] == b'\'' {
+                            j += 2;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        j += 1;
+                    }
+                }
+            }
+            b',' if depth == 0 => {
+                if let Some(alias) = subquery_alias_from_item(&select_text[item_start..i]) {
+                    aliases.push(alias);
+                }
+                item_start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    // Last item
+    if let Some(alias) = subquery_alias_from_item(&select_text[item_start..]) {
+        aliases.push(alias);
+    }
+
+    aliases
+}
+
+/// Check if a single SELECT item contains a `(SELECT ...)` subquery and has an AS alias.
+fn subquery_alias_from_item(item: &str) -> Option<String> {
+    let upper = item.to_uppercase();
+    if !upper.contains("(SELECT ") {
+        return None;
+    }
+    // Find the last top-level " AS " (not inside parentheses)
+    let bytes = item.as_bytes();
+    let mut depth: i32 = 0;
+    let mut last_as_pos: Option<usize> = None;
+    let mut i = 0;
+    while i < item.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            _ if depth == 0 => {
+                if i + 4 <= item.len() && upper[i..].starts_with(" AS ") {
+                    last_as_pos = Some(i + 4);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    let as_pos = last_as_pos?;
+    let alias = item[as_pos..].trim();
+    // Extract identifier: alphanumeric, underscore, or quoted
+    let alias = alias
+        .split(|c: char| !c.is_alphanumeric() && c != '_' && c != '"' && c != '`')
+        .next()
+        .unwrap_or(alias)
+        .trim_matches('"')
+        .trim_matches('`');
+    if alias.is_empty() {
+        None
+    } else {
+        Some(alias.to_string())
+    }
+}
+
+/// Check if an identifier appears as a whole word in text (case-insensitive).
+fn identifier_appears_in(text: &str, ident: &str) -> bool {
+    let text_upper = text.to_uppercase();
+    let ident_upper = ident.to_uppercase();
+    let mut search_from = 0;
+    while let Some(pos) = text_upper[search_from..].find(&ident_upper) {
+        let abs = search_from + pos;
+        let before_ok = abs == 0 || {
+            let c = text.as_bytes()[abs - 1];
+            !c.is_ascii_alphanumeric() && c != b'_' && c != b'.'
+        };
+        let after_pos = abs + ident_upper.len();
+        let after_ok = after_pos >= text_upper.len() || {
+            let c = text.as_bytes()[after_pos];
+            !c.is_ascii_alphanumeric() && c != b'_'
+        };
+        if before_ok && after_ok {
+            return true;
+        }
+        search_from = abs + 1;
+    }
+    false
+}
+
 /// Expand AGGREGATE() with AT modifiers in SQL
 pub fn expand_aggregate_with_at(sql: &str) -> AggregateExpandResult {
     let cte_expansion = expand_cte_queries(sql);
@@ -5593,6 +5705,29 @@ pub fn expand_aggregate_with_at(sql: &str) -> AggregateExpandResult {
                 String::new()
             }
         );
+    }
+
+    // If ORDER BY references an alias whose SELECT expression is a subquery,
+    // wrap the query to avoid DuckDB's "Alias has subquery" limitation.
+    if let Some(order_pos) = find_top_level_keyword(&result_sql, "ORDER BY", 0) {
+        let subquery_aliases = extract_subquery_aliases_from_select(&result_sql);
+        if !subquery_aliases.is_empty() {
+            let order_end = find_first_top_level_keyword(
+                &result_sql,
+                order_pos + 8,
+                &["LIMIT", "OFFSET"],
+            )
+            .unwrap_or(result_sql.len());
+            let order_text = &result_sql[order_pos + 8..order_end];
+            let needs_wrap = subquery_aliases
+                .iter()
+                .any(|alias| identifier_appears_in(order_text, alias));
+            if needs_wrap {
+                let trailing = result_sql[order_pos..].trim_end_matches(';').trim_end();
+                let inner = result_sql[..order_pos].trim_end().trim_end_matches(';').trim_end();
+                result_sql = format!("SELECT * FROM ({inner}) _q {trailing}");
+            }
+        }
     }
 
     AggregateExpandResult {
@@ -7538,5 +7673,29 @@ GROUP BY s.year";
         assert!(result.expanded_sql.contains(
             "FROM (SELECT * FROM (SELECT year, region FROM a UNION ALL SELECT year, region FROM b)) _inner"
         ));
+    }
+
+    #[test]
+    fn test_extract_subquery_aliases_from_select() {
+        let sql = "SELECT year, region, SUM(revenue) AS revenue, (SELECT SUM(revenue) FROM t _inner WHERE _inner.year IS NOT DISTINCT FROM _outer.year) AS year_total FROM sales_v _outer GROUP BY year, region";
+        let aliases = extract_subquery_aliases_from_select(sql);
+        assert_eq!(aliases, vec!["year_total"]);
+    }
+
+    #[test]
+    fn test_extract_subquery_aliases_no_subquery() {
+        let sql = "SELECT year, SUM(revenue) AS revenue FROM sales_v GROUP BY year";
+        let aliases = extract_subquery_aliases_from_select(sql);
+        assert!(aliases.is_empty());
+    }
+
+    #[test]
+    fn test_identifier_appears_in() {
+        assert!(identifier_appears_in("revenue/year_total", "year_total"));
+        assert!(identifier_appears_in("revenue/year_total", "revenue"));
+        assert!(!identifier_appears_in("revenue/year_total", "year"));
+        assert!(identifier_appears_in("year_total DESC", "year_total"));
+        assert!(identifier_appears_in(" year_total", "year_total"));
+        assert!(!identifier_appears_in("o.prodName", "year_total"));
     }
 }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -6283,13 +6283,25 @@ pub fn expand_aggregate_with_at(sql: &str) -> AggregateExpandResult {
     if let Some(order_pos) = find_top_level_keyword(&result_sql, "ORDER BY", 0) {
         let subquery_aliases = extract_subquery_aliases_from_select(&result_sql);
         if !subquery_aliases.is_empty() {
+            // Skip past "ORDER", whitespace, and "BY" to find the expression start
+            let mut expr_start = order_pos + 5; // skip "ORDER"
+            while expr_start < result_sql.len()
+                && result_sql.as_bytes()[expr_start].is_ascii_whitespace()
+            {
+                expr_start += 1;
+            }
+            if expr_start + 2 <= result_sql.len()
+                && result_sql.as_bytes()[expr_start..expr_start + 2].eq_ignore_ascii_case(b"BY")
+            {
+                expr_start += 2;
+            }
             let order_end = find_first_top_level_keyword(
                 &result_sql,
-                order_pos + 8,
+                expr_start,
                 &["LIMIT", "OFFSET"],
             )
             .unwrap_or(result_sql.len());
-            let order_text = &result_sql[order_pos + 8..order_end];
+            let order_text = &result_sql[expr_start..order_end];
             let needs_wrap = subquery_aliases
                 .iter()
                 .any(|alias| identifier_appears_in(order_text, alias));

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5221,23 +5221,23 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
     if !upper.contains("(SELECT ") {
         return None;
     }
-    // Find the last top-level " AS " (not inside parentheses)
-    let bytes = item.as_bytes();
+    // Find the last top-level " AS " (not inside parentheses).
+    // Use char_indices to stay on valid UTF-8 boundaries.
     let mut depth: i32 = 0;
     let mut last_as_pos: Option<usize> = None;
-    let mut i = 0;
-    while i < item.len() {
-        match bytes[i] {
-            b'(' => depth += 1,
-            b')' => depth -= 1,
-            _ if depth == 0 => {
-                if i + 4 <= item.len() && upper[i..].starts_with(" AS ") {
+    for (i, ch) in item.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth -= 1,
+            _ if depth == 0 && ch == ' ' => {
+                if upper[i..].starts_with(" AS ")
+                    && item.is_char_boundary(i + 4)
+                {
                     last_as_pos = Some(i + 4);
                 }
             }
             _ => {}
         }
-        i += 1;
     }
     let as_pos = last_as_pos?;
     let alias = item[as_pos..].trim();
@@ -5267,7 +5267,7 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
         let abs = search_from + pos;
         let before_ok = abs == 0 || {
             let c = stripped.as_bytes()[abs - 1];
-            !c.is_ascii_alphanumeric() && c != b'_' && c != b'.'
+            !c.is_ascii_alphanumeric() && c != b'_' && c != b'.' && c != b'"' && c != b'`'
         };
         let after_pos = abs + ident_upper.len();
         let after_ok = after_pos >= stripped_upper.len() || {
@@ -7762,6 +7762,9 @@ GROUP BY s.year";
         assert!(!identifier_appears_in("/* year_total */ revenue", "year_total"));
         // Should still match real identifiers alongside literals
         assert!(identifier_appears_in("'literal' || year_total", "year_total"));
+        // Should not match quoted qualified names like o."year_total"
+        assert!(!identifier_appears_in(r#"o."year_total""#, "year_total"));
+        assert!(!identifier_appears_in(r#"o.`year_total`"#, "year_total"));
     }
 
     #[test]
@@ -7770,5 +7773,13 @@ GROUP BY s.year";
         let sql = "SELECT 'a,b' || (SELECT 1) AS x FROM t";
         let aliases = extract_subquery_aliases_from_select(sql);
         assert_eq!(aliases, vec!["x"]);
+    }
+
+    #[test]
+    fn test_subquery_alias_from_item_multibyte() {
+        // Should not panic on multibyte UTF-8 characters
+        let item = " (SELECT 1) || '\u{00e9}' AS year_total";
+        let alias = subquery_alias_from_item(item);
+        assert_eq!(alias, Some("year_total".to_string()));
     }
 }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5593,12 +5593,46 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
         return None;
     }
     // Find the last top-level alias (not inside parentheses).
+    // Skip string literals and comments so quoted parens don't corrupt depth.
     let bytes = item.as_bytes();
     let mut depth: i32 = 0;
     let mut last_alias_start: Option<usize> = None;
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
+            b'\'' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+                continue;
+            }
+            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
             b'(' => depth += 1,
             b')' => {
                 depth -= 1;

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5177,23 +5177,23 @@ fn extract_subquery_aliases_from_select(sql: &str) -> Vec<String> {
     let bytes = select_text.as_bytes();
     let mut depth: i32 = 0;
     let mut item_start = 0;
+    let mut i = 0;
 
-    for i in 0..select_text.len() {
+    while i < select_text.len() {
         match bytes[i] {
             b'(' => depth += 1,
             b')' => depth -= 1,
             b'\'' => {
-                // Skip single-quoted strings
-                let mut j = i + 1;
-                while j < select_text.len() {
-                    if bytes[j] == b'\'' {
-                        if j + 1 < select_text.len() && bytes[j + 1] == b'\'' {
-                            j += 2;
+                i += 1;
+                while i < select_text.len() {
+                    if bytes[i] == b'\'' {
+                        if i + 1 < select_text.len() && bytes[i + 1] == b'\'' {
+                            i += 2;
                         } else {
                             break;
                         }
                     } else {
-                        j += 1;
+                        i += 1;
                     }
                 }
             }
@@ -5205,6 +5205,7 @@ fn extract_subquery_aliases_from_select(sql: &str) -> Vec<String> {
             }
             _ => {}
         }
+        i += 1;
     }
     // Last item
     if let Some(alias) = subquery_alias_from_item(&select_text[item_start..]) {
@@ -5254,20 +5255,23 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
     }
 }
 
-/// Check if an identifier appears as a whole word in text (case-insensitive).
+/// Check if an identifier appears as a whole word in text (case-insensitive),
+/// skipping string literals and comments.
 fn identifier_appears_in(text: &str, ident: &str) -> bool {
-    let text_upper = text.to_uppercase();
+    // Strip string literals and comments before scanning for the identifier.
+    let stripped = strip_literals_and_comments(text);
+    let stripped_upper = stripped.to_uppercase();
     let ident_upper = ident.to_uppercase();
     let mut search_from = 0;
-    while let Some(pos) = text_upper[search_from..].find(&ident_upper) {
+    while let Some(pos) = stripped_upper[search_from..].find(&ident_upper) {
         let abs = search_from + pos;
         let before_ok = abs == 0 || {
-            let c = text.as_bytes()[abs - 1];
+            let c = stripped.as_bytes()[abs - 1];
             !c.is_ascii_alphanumeric() && c != b'_' && c != b'.'
         };
         let after_pos = abs + ident_upper.len();
-        let after_ok = after_pos >= text_upper.len() || {
-            let c = text.as_bytes()[after_pos];
+        let after_ok = after_pos >= stripped_upper.len() || {
+            let c = stripped.as_bytes()[after_pos];
             !c.is_ascii_alphanumeric() && c != b'_'
         };
         if before_ok && after_ok {
@@ -5276,6 +5280,60 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
         search_from = abs + 1;
     }
     false
+}
+
+/// Replace string literals and comments with spaces to avoid false matches.
+fn strip_literals_and_comments(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out = text.to_string().into_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' => {
+                out[i] = b' ';
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                            out[i] = b' ';
+                            out[i + 1] = b' ';
+                            i += 2;
+                        } else {
+                            out[i] = b' ';
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        out[i] = b' ';
+                        i += 1;
+                    }
+                }
+            }
+            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    out[i] = b' ';
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                out[i] = b' ';
+                out[i + 1] = b' ';
+                i += 2;
+                while i + 1 < bytes.len() {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        out[i] = b' ';
+                        out[i + 1] = b' ';
+                        i += 2;
+                        break;
+                    }
+                    out[i] = b' ';
+                    i += 1;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| text.to_string())
 }
 
 /// Expand AGGREGATE() with AT modifiers in SQL
@@ -7696,5 +7754,21 @@ GROUP BY s.year";
         assert!(identifier_appears_in("year_total DESC", "year_total"));
         assert!(identifier_appears_in(" year_total", "year_total"));
         assert!(!identifier_appears_in("o.prodName", "year_total"));
+        // Should not match inside string literals
+        assert!(!identifier_appears_in("'year_total'", "year_total"));
+        assert!(!identifier_appears_in("'contains year_total inside'", "year_total"));
+        // Should not match inside comments
+        assert!(!identifier_appears_in("-- year_total\nrevenue", "year_total"));
+        assert!(!identifier_appears_in("/* year_total */ revenue", "year_total"));
+        // Should still match real identifiers alongside literals
+        assert!(identifier_appears_in("'literal' || year_total", "year_total"));
+    }
+
+    #[test]
+    fn test_extract_subquery_aliases_with_string_in_item() {
+        // Comma inside a string literal should not split the item
+        let sql = "SELECT 'a,b' || (SELECT 1) AS x FROM t";
+        let aliases = extract_subquery_aliases_from_select(sql);
+        assert_eq!(aliases, vec!["x"]);
     }
 }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5545,48 +5545,71 @@ fn item_has_subquery(item: &str) -> bool {
     false
 }
 
-/// Check if a single SELECT item contains a `(SELECT ...)` subquery and has an AS alias.
+/// Check if a single SELECT item contains a `(SELECT ...)` subquery and has an alias.
+/// Supports both explicit (`AS alias`) and implicit (`(SELECT ...) alias`) forms.
 fn subquery_alias_from_item(item: &str) -> Option<String> {
     if !item_has_subquery(item) {
         return None;
     }
-    // Find the last top-level whitespace-AS-whitespace (not inside parentheses).
-    // Handles spaces, tabs, and newlines around AS.
+    // Find the last top-level alias (not inside parentheses).
     let bytes = item.as_bytes();
     let mut depth: i32 = 0;
-    let mut last_as_end: Option<usize> = None;
+    let mut last_alias_start: Option<usize> = None;
     let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
             b'(' => depth += 1,
-            b')' => depth -= 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    // After closing paren at depth 0, check for trailing alias
+                    let mut j = i + 1;
+                    while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                        j += 1;
+                    }
+                    if j < bytes.len() {
+                        // Check for explicit "AS" keyword
+                        if j + 2 <= bytes.len()
+                            && bytes[j..j + 2].eq_ignore_ascii_case(b"AS")
+                            && (j + 2 >= bytes.len() || bytes[j + 2].is_ascii_whitespace())
+                        {
+                            let mut end = j + 2;
+                            while end < bytes.len() && bytes[end].is_ascii_whitespace() {
+                                end += 1;
+                            }
+                            last_alias_start = Some(end);
+                        } else if bytes[j].is_ascii_alphabetic() || bytes[j] == b'_'
+                            || bytes[j] == b'"' || bytes[j] == b'`'
+                        {
+                            // Implicit alias (no AS keyword)
+                            last_alias_start = Some(j);
+                        }
+                    }
+                }
+            }
             c if depth == 0 && c.is_ascii_whitespace() => {
-                // Skip leading whitespace
-                let ws_start = i;
+                // Also check for AS keyword in non-subquery trailing context
                 while i < bytes.len() && bytes[i].is_ascii_whitespace() {
                     i += 1;
                 }
-                // Check for "AS" followed by whitespace
                 if i + 2 <= bytes.len()
                     && bytes[i..i + 2].eq_ignore_ascii_case(b"AS")
                     && (i + 2 >= bytes.len() || bytes[i + 2].is_ascii_whitespace())
                 {
-                    let _ = ws_start;
                     let mut end = i + 2;
                     while end < bytes.len() && bytes[end].is_ascii_whitespace() {
                         end += 1;
                     }
-                    last_as_end = Some(end);
+                    last_alias_start = Some(end);
                 }
-                continue; // already advanced i past whitespace
+                continue;
             }
             _ => {}
         }
         i += 1;
     }
-    let as_end = last_as_end?;
-    let alias = item[as_end..].trim();
-    // Extract identifier: alphanumeric, underscore, or quoted
+    let alias_start = last_alias_start?;
+    let alias = item[alias_start..].trim();
     let alias = alias
         .split(|c: char| !c.is_alphanumeric() && c != '_' && c != '"' && c != '`')
         .next()
@@ -5600,32 +5623,18 @@ fn subquery_alias_from_item(item: &str) -> Option<String> {
     }
 }
 
-/// Check if an identifier appears as a top-level whole word in text (case-insensitive),
-/// skipping string literals, comments, and content inside parentheses.
+/// Check if an identifier appears as a whole word in text (case-insensitive),
+/// skipping string literals and comments. Matches at any parenthesis depth
+/// so that `COALESCE(year_total, 0)` still triggers wrapping.
 fn identifier_appears_in(text: &str, ident: &str) -> bool {
     let stripped = strip_literals_and_comments(text);
     let stripped_upper = stripped.to_uppercase();
     let ident_upper = ident.to_uppercase();
-
-    // Pre-compute parenthesis depth at each byte position
     let bytes = stripped.as_bytes();
-    let mut depths = vec![0i32; bytes.len()];
-    let mut depth: i32 = 0;
-    for i in 0..bytes.len() {
-        if bytes[i] == b'(' {
-            depth += 1;
-        }
-        depths[i] = depth;
-        if bytes[i] == b')' {
-            depth -= 1;
-        }
-    }
 
     let mut search_from = 0;
     while let Some(pos) = stripped_upper[search_from..].find(&ident_upper) {
         let abs = search_from + pos;
-        // Only match at top level (outside parentheses)
-        let at_top_level = depths[abs] == 0;
         let before_ok = abs == 0 || {
             let c = bytes[abs - 1];
             if c == b'"' || c == b'`' {
@@ -5639,7 +5648,7 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
             let c = bytes[after_pos];
             !c.is_ascii_alphanumeric() && c != b'_'
         };
-        if at_top_level && before_ok && after_ok {
+        if before_ok && after_ok {
             return true;
         }
         search_from = abs + 1;
@@ -8243,10 +8252,10 @@ GROUP BY s.year";
         // But bare quoted aliases like "year_total" should match
         assert!(identifier_appears_in(r#""year_total""#, "year_total"));
         assert!(identifier_appears_in(r#"`year_total`"#, "year_total"));
-        // Should not match inside parentheses (e.g., function arguments)
-        assert!(!identifier_appears_in("EXTRACT(YEAR FROM o.ts)", "year"));
-        assert!(!identifier_appears_in("COALESCE(year_total, 0)", "year_total"));
-        // But top-level references should still match
+        // Should match inside parentheses (e.g., COALESCE(year_total, 0))
+        assert!(identifier_appears_in("COALESCE(year_total, 0)", "year_total"));
+        assert!(identifier_appears_in("(year_total)", "year_total"));
+        // Top-level references should still match
         assert!(identifier_appears_in("year_total + COALESCE(x, 0)", "year_total"));
     }
 
@@ -8285,6 +8294,12 @@ GROUP BY s.year";
         assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
         // CTE subquery: (WITH ... SELECT ...)
         let item = " (WITH cte AS (SELECT 1) SELECT * FROM cte) AS year_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
+        // Implicit alias (no AS keyword)
+        let item = " (SELECT 1) year_total";
+        assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
+        // Quoted implicit alias
+        let item = r#" (SELECT 1) "year_total""#;
         assert_eq!(subquery_alias_from_item(item), Some("year_total".to_string()));
     }
 

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5524,21 +5524,21 @@ fn extract_subquery_aliases_from_select(sql: &str) -> Vec<String> {
 
 /// Check if a single SELECT item contains a `(SELECT ...)` subquery and has an AS alias.
 fn subquery_alias_from_item(item: &str) -> Option<String> {
-    let upper = item.to_uppercase();
-    if !upper.contains("(SELECT ") {
+    if !item.to_uppercase().contains("(SELECT ") {
         return None;
     }
     // Find the last top-level " AS " (not inside parentheses).
-    // Use char_indices to stay on valid UTF-8 boundaries.
+    // Compare directly on `item` using case-insensitive matching to avoid
+    // byte-offset mismatches between `item` and its uppercase form.
     let mut depth: i32 = 0;
     let mut last_as_pos: Option<usize> = None;
     for (i, ch) in item.char_indices() {
         match ch {
             '(' => depth += 1,
             ')' => depth -= 1,
-            _ if depth == 0 && ch == ' ' => {
-                if upper[i..].starts_with(" AS ")
-                    && item.is_char_boundary(i + 4)
+            ' ' if depth == 0 => {
+                if item[i..].len() >= 4
+                    && item[i..].as_bytes()[1..4].eq_ignore_ascii_case(b"AS ")
                 {
                     last_as_pos = Some(i + 4);
                 }
@@ -5574,7 +5574,13 @@ fn identifier_appears_in(text: &str, ident: &str) -> bool {
         let abs = search_from + pos;
         let before_ok = abs == 0 || {
             let c = stripped.as_bytes()[abs - 1];
-            !c.is_ascii_alphanumeric() && c != b'_' && c != b'.' && c != b'"' && c != b'`'
+            if c == b'"' || c == b'`' {
+                // Bare quoted identifier like "year_total" is OK;
+                // qualified like o."year_total" (dot before quote) is not.
+                abs < 2 || stripped.as_bytes()[abs - 2] != b'.'
+            } else {
+                !c.is_ascii_alphanumeric() && c != b'_' && c != b'.'
+            }
         };
         let after_pos = abs + ident_upper.len();
         let after_ok = after_pos >= stripped_upper.len() || {
@@ -8174,9 +8180,12 @@ GROUP BY s.year";
         assert!(!identifier_appears_in("/* year_total */ revenue", "year_total"));
         // Should still match real identifiers alongside literals
         assert!(identifier_appears_in("'literal' || year_total", "year_total"));
-        // Should not match quoted qualified names like o."year_total"
+        // Should not match qualified quoted names like o."year_total"
         assert!(!identifier_appears_in(r#"o."year_total""#, "year_total"));
         assert!(!identifier_appears_in(r#"o.`year_total`"#, "year_total"));
+        // But bare quoted aliases like "year_total" should match
+        assert!(identifier_appears_in(r#""year_total""#, "year_total"));
+        assert!(identifier_appears_in(r#"`year_total`"#, "year_total"));
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5170,8 +5170,7 @@ fn validate_set_expression_requirements(
 /// Extract alias names of SELECT items whose expressions contain subqueries.
 fn extract_subquery_aliases_from_select(sql: &str) -> Vec<String> {
     let from_pos = find_top_level_keyword(sql, "FROM", 0).unwrap_or(sql.len());
-    let upper = sql.to_uppercase();
-    let select_start = upper.find("SELECT").map(|p| p + 6).unwrap_or(0);
+    let select_start = find_top_level_keyword(sql, "SELECT", 0).map(|p| p + 6).unwrap_or(0);
     let select_text = &sql[select_start..from_pos];
 
     let mut aliases = Vec::new();

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5533,10 +5533,16 @@ fn item_has_subquery(item: &str) -> bool {
             while j < bytes.len() && bytes[j].is_ascii_whitespace() {
                 j += 1;
             }
-            if j + 6 <= bytes.len() && bytes[j..j + 6].eq_ignore_ascii_case(b"SELECT") {
+            if j + 6 <= bytes.len()
+                && bytes[j..j + 6].eq_ignore_ascii_case(b"SELECT")
+                && (j + 6 >= bytes.len() || !bytes[j + 6].is_ascii_alphanumeric() && bytes[j + 6] != b'_')
+            {
                 return true;
             }
-            if j + 4 <= bytes.len() && bytes[j..j + 4].eq_ignore_ascii_case(b"WITH") {
+            if j + 4 <= bytes.len()
+                && bytes[j..j + 4].eq_ignore_ascii_case(b"WITH")
+                && (j + 4 >= bytes.len() || !bytes[j + 4].is_ascii_alphanumeric() && bytes[j + 4] != b'_')
+            {
                 return true;
             }
         }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -5942,6 +5942,14 @@ pub fn expand_aggregate_with_at(sql: &str) -> AggregateExpandResult {
         );
     }
 
+    if let Some(rewritten_sql) =
+        std::panic::catch_unwind(|| parser_ffi::inline_order_by_subquery_aliases(&result_sql))
+            .ok()
+            .flatten()
+    {
+        result_sql = rewritten_sql;
+    }
+
     AggregateExpandResult {
         had_aggregate,
         expanded_sql: result_sql,


### PR DESCRIPTION
Fixes #28.

When an expanded AGGREGATE ... AT SELECT alias contains a scalar subquery, DuckDB can order by the alias directly but fails when that alias is referenced inside a complex ORDER BY expression such as revenue / year_total.

This rewrites those complex ORDER BY expressions through the DuckDB parser by inlining SELECT aliases only when the expression references a subquery-backed alias. Simple ORDER BY year_total and qualified tie-breakers stay in the original query scope.

Tests added for the original ratio sort, qualified tie-breakers, and simple alias ordering.