### PR TITLE
Fix multi-statement measure view batches

### DIFF
--- a/include/yardstick_ffi.h
+++ b/include/yardstick_ffi.h
@@ -330,6 +330,7 @@ char* yardstick_expand_curly_braces(const char* sql);
 char* yardstick_extract_view_name(const char* sql);
 char* yardstick_extract_drop_view_name(const char* sql);
 void* yardstick_snapshot_measure_view(const char* view_name);
+void* yardstick_empty_measure_view_snapshot(void);
 void yardstick_restore_measure_view_snapshot(const char* view_name, void* snapshot);
 void yardstick_free_measure_view_snapshot(void* snapshot);
 struct YardstickCreateViewResult yardstick_process_create_view(const char* sql);

--- a/include/yardstick_ffi.h
+++ b/include/yardstick_ffi.h
@@ -327,6 +327,10 @@ bool yardstick_has_curly_brace(const char* sql);
 bool yardstick_has_at_syntax(const char* sql);
 
 char* yardstick_expand_curly_braces(const char* sql);
+char* yardstick_extract_view_name(const char* sql);
+void* yardstick_snapshot_measure_view(const char* view_name);
+void yardstick_restore_measure_view_snapshot(const char* view_name, void* snapshot);
+void yardstick_free_measure_view_snapshot(void* snapshot);
 struct YardstickCreateViewResult yardstick_process_create_view(const char* sql);
 struct YardstickAggregateResult yardstick_expand_aggregate(const char* sql);
 struct YardstickMeasureAggResult yardstick_get_measure_aggregation(const char* column_name);

--- a/include/yardstick_ffi.h
+++ b/include/yardstick_ffi.h
@@ -328,6 +328,7 @@ bool yardstick_has_at_syntax(const char* sql);
 
 char* yardstick_expand_curly_braces(const char* sql);
 char* yardstick_extract_view_name(const char* sql);
+char* yardstick_extract_drop_view_name(const char* sql);
 void* yardstick_snapshot_measure_view(const char* view_name);
 void yardstick_restore_measure_view_snapshot(const char* view_name, void* snapshot);
 void yardstick_free_measure_view_snapshot(void* snapshot);

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -870,6 +870,35 @@ static bool IsUnqualifiedOrTemporarySchemaReference(const std::string &qualified
            EqualsCaseInsensitive(schema, "pg_temp");
 }
 
+static bool IsExtractFromKeyword(const std::string &sql, idx_t from_pos) {
+    idx_t depth = 0;
+    for (idx_t i = from_pos; i > 0; i--) {
+        char c = sql[i - 1];
+        if (c == ')') {
+            depth++;
+            continue;
+        }
+        if (c != '(') {
+            continue;
+        }
+        if (depth > 0) {
+            depth--;
+            continue;
+        }
+
+        idx_t token_end = i - 1;
+        while (token_end > 0 && std::isspace(static_cast<unsigned char>(sql[token_end - 1]))) {
+            token_end--;
+        }
+        idx_t token_start = token_end;
+        while (token_start > 0 && IsIdentifierChar(sql[token_start - 1])) {
+            token_start--;
+        }
+        return EqualsCaseInsensitive(sql.substr(token_start, token_end - token_start), "EXTRACT");
+    }
+    return false;
+}
+
 static bool StatementTextReadsFromView(const std::string &sql,
                                        const std::string &view_name,
                                        bool qualified_permanent) {
@@ -955,7 +984,11 @@ static bool StatementTextReadsFromView(const std::string &sql,
         }
 
         size_t pos = i;
-        if (!ConsumeKeyword(sql, pos, "FROM") && !ConsumeKeyword(sql, pos, "JOIN")) {
+        bool from_keyword = ConsumeKeyword(sql, pos, "FROM");
+        if (from_keyword && IsExtractFromKeyword(sql, i)) {
+            continue;
+        }
+        if (!from_keyword && !ConsumeKeyword(sql, pos, "JOIN")) {
             continue;
         }
 

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -498,6 +498,25 @@ static bool StartsWithCreateViewStatement(const std::string &sql) {
     return ConsumeKeyword(sql, pos, "VIEW");
 }
 
+static bool IsTemporaryCreateViewStatement(const std::string &sql) {
+    size_t pos = SkipWhitespaceAndComments(sql, 0);
+    if (!ConsumeKeyword(sql, pos, "CREATE")) {
+        return false;
+    }
+
+    pos = SkipWhitespaceAndComments(sql, pos);
+    if (ConsumeKeyword(sql, pos, "OR")) {
+        pos = SkipWhitespaceAndComments(sql, pos);
+        if (!ConsumeKeyword(sql, pos, "REPLACE")) {
+            return false;
+        }
+        pos = SkipWhitespaceAndComments(sql, pos);
+    }
+
+    return ConsumeKeyword(sql, pos, "TEMPORARY") ||
+           ConsumeKeyword(sql, pos, "TEMP");
+}
+
 struct MeasureRewriteResult {
     bool had_measure_view = false;
     bool had_aggregate = false;
@@ -508,6 +527,14 @@ struct MeasureRewriteResult {
 static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::string &query) {
     MeasureRewriteResult rewrite_result;
     std::vector<std::string> rewritten_statements;
+    std::vector<std::string> temporary_measure_views;
+    auto cleanup_temporary_measure_views = [&temporary_measure_views]() {
+        for (auto it = temporary_measure_views.rbegin(); it != temporary_measure_views.rend(); ++it) {
+            std::string drop_sql = "DROP VIEW " + *it;
+            yardstick_drop_measure_view_from_sql(drop_sql.c_str());
+        }
+        temporary_measure_views.clear();
+    };
 
     for (auto statement : SplitSqlStatements(query)) {
         StringUtil::Trim(statement);
@@ -521,16 +548,21 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
         if (yardstick_has_as_measure(statement_body.c_str()) &&
             StartsWithCreateViewStatement(statement_body)) {
             std::string rewritten_statement = RewritePercentileWithinGroup(statement_body);
+            bool is_temporary_measure_view = IsTemporaryCreateViewStatement(statement_body);
             YardstickCreateViewResult result = yardstick_process_create_view(rewritten_statement.c_str());
 
             if (result.error) {
                 rewrite_result.error = result.error;
                 yardstick_free_create_view_result(result);
+                cleanup_temporary_measure_views();
                 return rewrite_result;
             }
 
             if (result.is_measure_view) {
                 rewrite_result.had_measure_view = true;
+                if (is_temporary_measure_view && result.view_name) {
+                    temporary_measure_views.emplace_back(result.view_name);
+                }
                 rewritten_statements.push_back(RewritePercentileWithinGroup(result.clean_sql));
             } else {
                 rewritten_statements.push_back(statement);
@@ -568,6 +600,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
         rewrite_result.rewritten_sql += rewritten_statements[i];
     }
 
+    cleanup_temporary_measure_views();
     return rewrite_result;
 }
 

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -565,34 +565,6 @@ static bool EqualsCaseInsensitive(const std::string &left, const std::string &ri
     return true;
 }
 
-static bool ContainsIdentifier(const std::string &sql, const std::string &identifier) {
-    if (identifier.empty() || sql.size() < identifier.size()) {
-        return false;
-    }
-
-    for (idx_t i = 0; i + identifier.size() <= sql.size(); i++) {
-        bool matches = true;
-        for (idx_t j = 0; j < identifier.size(); j++) {
-            if (std::tolower(static_cast<unsigned char>(sql[i + j])) !=
-                std::tolower(static_cast<unsigned char>(identifier[j]))) {
-                matches = false;
-                break;
-            }
-        }
-        if (!matches) {
-            continue;
-        }
-
-        bool left_boundary = i == 0 || !IsIdentifierChar(sql[i - 1]);
-        idx_t end = i + identifier.size();
-        bool right_boundary = end >= sql.size() || !IsIdentifierChar(sql[end]);
-        if (left_boundary && right_boundary) {
-            return true;
-        }
-    }
-    return false;
-}
-
 static bool RemoveCaseInsensitive(std::vector<std::string> &values, const std::string &value) {
     for (auto it = values.begin(); it != values.end(); ++it) {
         if (EqualsCaseInsensitive(*it, value)) {
@@ -603,8 +575,20 @@ static bool RemoveCaseInsensitive(std::vector<std::string> &values, const std::s
     return false;
 }
 
-static bool HasTemporarySnapshot(const std::vector<MeasureViewSnapshot> &snapshots,
-                                 const std::string &view_name) {
+static bool RestoreAndRemoveTemporarySnapshot(std::vector<MeasureViewSnapshot> &snapshots,
+                                              const std::string &view_name) {
+    for (auto it = snapshots.begin(); it != snapshots.end(); ++it) {
+        if (EqualsCaseInsensitive(it->view_name, view_name)) {
+            yardstick_restore_measure_view_snapshot(it->view_name.c_str(), it->snapshot);
+            snapshots.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool HasMeasureSnapshot(const std::vector<MeasureViewSnapshot> &snapshots,
+                               const std::string &view_name) {
     for (auto &snapshot : snapshots) {
         if (EqualsCaseInsensitive(snapshot.view_name, view_name)) {
             return true;
@@ -613,8 +597,132 @@ static bool HasTemporarySnapshot(const std::vector<MeasureViewSnapshot> &snapsho
     return false;
 }
 
+static std::string SelectPortionForTableAnalysis(const std::string &sql) {
+    std::string dollar_quote_end;
+    bool in_single_quote = false;
+    bool in_double_quote = false;
+    bool in_line_comment = false;
+    bool in_block_comment = false;
+    idx_t depth = 0;
+
+    for (idx_t i = 0; i < sql.size(); i++) {
+        char c = sql[i];
+        char next = i + 1 < sql.size() ? sql[i + 1] : '\0';
+
+        if (in_line_comment) {
+            if (c == '\n') {
+                in_line_comment = false;
+            }
+            continue;
+        }
+        if (in_block_comment) {
+            if (c == '*' && next == '/') {
+                in_block_comment = false;
+                i++;
+            }
+            continue;
+        }
+        if (!dollar_quote_end.empty()) {
+            if (sql.compare(i, dollar_quote_end.size(), dollar_quote_end) == 0) {
+                i += dollar_quote_end.size() - 1;
+                dollar_quote_end.clear();
+            }
+            continue;
+        }
+        if (in_single_quote) {
+            if (c == '\'' && next == '\'') {
+                i++;
+            } else if (c == '\'') {
+                in_single_quote = false;
+            }
+            continue;
+        }
+        if (in_double_quote) {
+            if (c == '"' && next == '"') {
+                i++;
+            } else if (c == '"') {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        if (c == '-' && next == '-') {
+            in_line_comment = true;
+            i++;
+            continue;
+        }
+        if (c == '/' && next == '*') {
+            in_block_comment = true;
+            i++;
+            continue;
+        }
+        if (c == '\'') {
+            in_single_quote = true;
+            continue;
+        }
+        if (c == '"') {
+            in_double_quote = true;
+            continue;
+        }
+        if (c == '$') {
+            idx_t tag_end = i + 1;
+            while (tag_end < sql.size() && sql[tag_end] != '$') {
+                char tag_char = sql[tag_end];
+                if (!std::isalnum(static_cast<unsigned char>(tag_char)) && tag_char != '_') {
+                    break;
+                }
+                tag_end++;
+            }
+            if (tag_end < sql.size() && sql[tag_end] == '$') {
+                dollar_quote_end = sql.substr(i, tag_end - i + 1);
+                i = tag_end;
+                continue;
+            }
+        }
+
+        if (c == '(') {
+            depth++;
+            continue;
+        }
+        if (c == ')' && depth > 0) {
+            depth--;
+            continue;
+        }
+
+        size_t pos = i;
+        if (depth == 0 && ConsumeKeyword(sql, pos, "SELECT")) {
+            return sql.substr(i);
+        }
+    }
+
+    return sql;
+}
+
+static bool StatementReadsFromView(const std::string &sql, const std::string &view_name) {
+    std::string select_sql = SelectPortionForTableAnalysis(sql);
+    YardstickSelectInfo *info = yardstick_parse_select(select_sql.c_str());
+    if (!info || info->error) {
+        if (info) {
+            yardstick_free_select_info(info);
+        }
+        return false;
+    }
+
+    bool found = false;
+    for (idx_t i = 0; i < info->table_count; i++) {
+        if (info->tables[i].table_name &&
+            EqualsCaseInsensitive(info->tables[i].table_name, view_name)) {
+            found = true;
+            break;
+        }
+    }
+
+    yardstick_free_select_info(info);
+    return found;
+}
+
 static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
-                                              const std::vector<MeasureViewSnapshot> &temporary_snapshots,
+                                              std::vector<MeasureViewSnapshot> &temporary_snapshots,
                                               std::vector<std::string> &pending_temporary_views,
                                               std::vector<MeasureViewSnapshot> &snapshots) {
     char *extracted_view_name = yardstick_extract_drop_view_name(sql.c_str());
@@ -625,9 +733,10 @@ static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
     std::string view_name = extracted_view_name;
     yardstick_free(extracted_view_name);
 
-    if (HasTemporarySnapshot(temporary_snapshots, view_name)) {
+    if (HasMeasureSnapshot(temporary_snapshots, view_name)) {
         RemoveCaseInsensitive(pending_temporary_views, view_name);
         yardstick_drop_measure_view_from_sql(sql.c_str());
+        RestoreAndRemoveTemporarySnapshot(temporary_snapshots, view_name);
         return true;
     }
 
@@ -760,7 +869,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         if (result.had_aggregate) {
             rewrite_result.had_aggregate = true;
             for (auto it = pending_temporary_views.begin(); it != pending_temporary_views.end();) {
-                if (ContainsIdentifier(aggregate_statement, *it)) {
+                if (StatementReadsFromView(aggregate_statement, *it)) {
                     it = pending_temporary_views.erase(it);
                 } else {
                     ++it;

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -495,13 +495,9 @@ static bool StartsWithCreateViewStatement(const std::string &sql) {
 
 struct MeasureRewriteResult {
     bool had_measure_view = false;
-    std::string rewritten_sql;
-    std::string error;
-};
-
-struct AggregateRewriteResult {
     bool had_aggregate = false;
     std::string rewritten_sql;
+    std::string error;
 };
 
 static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::string &query) {
@@ -514,50 +510,28 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
             continue;
         }
 
-        yardstick_drop_measure_view_from_sql(statement.c_str());
+        auto statement_body = statement.substr(SkipWhitespaceAndComments(statement, 0));
+        yardstick_drop_measure_view_from_sql(statement_body.c_str());
 
-        if (!yardstick_has_as_measure(statement.c_str()) ||
-            !StartsWithCreateViewStatement(statement)) {
-            rewritten_statements.push_back(statement);
-            continue;
-        }
+        if (yardstick_has_as_measure(statement_body.c_str()) &&
+            StartsWithCreateViewStatement(statement_body)) {
+            std::string rewritten_statement = RewritePercentileWithinGroup(statement_body);
+            YardstickCreateViewResult result = yardstick_process_create_view(rewritten_statement.c_str());
 
-        std::string rewritten_statement = RewritePercentileWithinGroup(statement);
-        YardstickCreateViewResult result = yardstick_process_create_view(rewritten_statement.c_str());
+            if (result.error) {
+                rewrite_result.error = result.error;
+                yardstick_free_create_view_result(result);
+                return rewrite_result;
+            }
 
-        if (result.error) {
-            rewrite_result.error = result.error;
+            if (result.is_measure_view) {
+                rewrite_result.had_measure_view = true;
+                rewritten_statements.push_back(RewritePercentileWithinGroup(result.clean_sql));
+            } else {
+                rewritten_statements.push_back(statement);
+            }
+
             yardstick_free_create_view_result(result);
-            return rewrite_result;
-        }
-
-        if (result.is_measure_view) {
-            rewrite_result.had_measure_view = true;
-            rewritten_statements.push_back(RewritePercentileWithinGroup(result.clean_sql));
-        } else {
-            rewritten_statements.push_back(statement);
-        }
-
-        yardstick_free_create_view_result(result);
-    }
-
-    for (idx_t i = 0; i < rewritten_statements.size(); i++) {
-        if (i > 0) {
-            rewrite_result.rewritten_sql += ";\n";
-        }
-        rewrite_result.rewritten_sql += rewritten_statements[i];
-    }
-
-    return rewrite_result;
-}
-
-static AggregateRewriteResult RewriteAggregatesStatementByStatement(const std::string &query) {
-    AggregateRewriteResult rewrite_result;
-    std::vector<std::string> rewritten_statements;
-
-    for (auto statement : SplitSqlStatements(query)) {
-        StringUtil::Trim(statement);
-        if (statement.empty()) {
             continue;
         }
 
@@ -626,13 +600,6 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
         if (measure_rewrite.had_measure_view) {
             had_measure_rewrite = true;
             sql_to_check = std::move(measure_rewrite.rewritten_sql);
-        }
-    }
-
-    if (had_measure_rewrite && yardstick_has_aggregate(sql_to_check.c_str())) {
-        auto aggregate_rewrite = RewriteAggregatesStatementByStatement(sql_to_check);
-        if (aggregate_rewrite.had_aggregate) {
-            sql_to_check = std::move(aggregate_rewrite.rewritten_sql);
         }
     }
 
@@ -732,13 +699,6 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
         if (measure_rewrite.had_measure_view) {
             had_measure_rewrite = true;
             sql_to_check = std::move(measure_rewrite.rewritten_sql);
-        }
-    }
-
-    if (had_measure_rewrite && yardstick_has_aggregate(sql_to_check.c_str())) {
-        auto aggregate_rewrite = RewriteAggregatesStatementByStatement(sql_to_check);
-        if (aggregate_rewrite.had_aggregate) {
-            sql_to_check = std::move(aggregate_rewrite.rewritten_sql);
         }
     }
 

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -906,7 +906,8 @@ static bool StatementReadsFromView(const std::string &sql, const std::string &vi
 
     bool found = false;
     for (idx_t i = 0; i < info->table_count; i++) {
-        if (info->tables[i].table_name &&
+        if (!info->tables[i].is_subquery &&
+            info->tables[i].table_name &&
             TableRefMatchesView(info->tables[i].table_name, view_name)) {
             found = true;
             break;
@@ -1042,6 +1043,14 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         }
         deferred_drop_views.clear();
     };
+    auto has_deferred_drop_view = [&](const std::string &view_name) {
+        for (auto &drop_view : deferred_drop_views) {
+            if (EqualsCaseInsensitive(drop_view.view_name, view_name)) {
+                return true;
+            }
+        }
+        return false;
+    };
 
     for (auto statement : SplitSqlStatements(query)) {
         StringUtil::Trim(statement);
@@ -1104,6 +1113,16 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 snapshot = SnapshotMeasureView(view_name);
                 has_snapshot = true;
             }
+            bool preapplied_deferred_drop = false;
+            if (is_temporary_measure_view && !view_name.empty() &&
+                has_deferred_drop_view(view_name)) {
+                apply_deferred_drop_views();
+                if (has_snapshot) {
+                    yardstick_free_measure_view_snapshot(snapshot.snapshot);
+                    has_snapshot = false;
+                }
+                preapplied_deferred_drop = true;
+            }
             YardstickCreateViewResult result = yardstick_process_create_view(rewritten_statement.c_str());
 
             if (result.error) {
@@ -1122,7 +1141,9 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 if (view_name.empty() && result.view_name) {
                     view_name = result.view_name;
                 }
-                apply_deferred_drop_views(view_name);
+                if (!preapplied_deferred_drop) {
+                    apply_deferred_drop_views(view_name);
+                }
                 if (is_temporary_measure_view && !view_name.empty()) {
                     if (has_snapshot) {
                         temporary_snapshots.push_back(snapshot);

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -490,6 +490,11 @@ static bool StartsWithCreateViewStatement(const std::string &sql) {
         pos = SkipWhitespaceAndComments(sql, pos);
     }
 
+    if (ConsumeKeyword(sql, pos, "TEMPORARY") ||
+        ConsumeKeyword(sql, pos, "TEMP")) {
+        pos = SkipWhitespaceAndComments(sql, pos);
+    }
+
     return ConsumeKeyword(sql, pos, "VIEW");
 }
 

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -45,6 +45,7 @@ extern "C" {
     bool yardstick_has_aggregate(const char *sql);
     bool yardstick_drop_measure_view_from_sql(const char *sql);
     char *yardstick_extract_view_name(const char *sql);
+    char *yardstick_extract_drop_view_name(const char *sql);
     void *yardstick_snapshot_measure_view(const char *view_name);
     void yardstick_restore_measure_view_snapshot(const char *view_name, void *snapshot);
     void yardstick_free_measure_view_snapshot(void *snapshot);
@@ -551,6 +552,20 @@ static MeasureViewSnapshot SnapshotMeasureView(const std::string &view_name) {
     return {view_name, yardstick_snapshot_measure_view(view_name.c_str())};
 }
 
+static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
+                                              std::vector<MeasureViewSnapshot> &snapshots) {
+    char *extracted_view_name = yardstick_extract_drop_view_name(sql.c_str());
+    if (!extracted_view_name) {
+        return false;
+    }
+
+    std::string view_name = extracted_view_name;
+    yardstick_free(extracted_view_name);
+    snapshots.push_back(SnapshotMeasureView(view_name));
+    yardstick_drop_measure_view_from_sql(sql.c_str());
+    return true;
+}
+
 static string EscapeSqlStringLiteral(const string &sql) {
     string escaped_sql;
     for (char c : sql) {
@@ -595,7 +610,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         }
 
         auto statement_body = statement.substr(SkipWhitespaceAndComments(statement, 0));
-        yardstick_drop_measure_view_from_sql(statement_body.c_str());
+        SnapshotAndDropMeasureViewFromSql(statement_body, permanent_snapshots);
 
         if (yardstick_has_as_measure(statement_body.c_str()) &&
             StartsWithCreateViewStatement(statement_body)) {
@@ -651,12 +666,18 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
             continue;
         }
 
-        if (!yardstick_has_aggregate(statement.c_str())) {
+        std::string aggregate_statement = statement_body;
+        std::string semantic_stripped;
+        if (StartsWithSemantic(aggregate_statement, semantic_stripped)) {
+            aggregate_statement = semantic_stripped;
+        }
+
+        if (!yardstick_has_aggregate(aggregate_statement.c_str())) {
             rewritten_statements.push_back(statement);
             continue;
         }
 
-        YardstickAggregateResult result = yardstick_expand_aggregate(statement.c_str());
+        YardstickAggregateResult result = yardstick_expand_aggregate(aggregate_statement.c_str());
         if (result.error) {
             yardstick_free_aggregate_result(result);
             rewritten_statements.push_back(statement);

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -942,6 +942,10 @@ static bool ExtractDropViewNameFromSql(const std::string &sql, std::string &view
         return false;
     }
     pos = SkipWhitespaceAndComments(sql, pos);
+    if (ConsumeKeyword(sql, pos, "CASCADE") ||
+        ConsumeKeyword(sql, pos, "RESTRICT")) {
+        pos = SkipWhitespaceAndComments(sql, pos);
+    }
     while (pos < sql.size() && sql[pos] == ';') {
         pos++;
         pos = SkipWhitespaceAndComments(sql, pos);
@@ -1022,6 +1026,10 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         }
 
         auto statement_body = statement.substr(SkipWhitespaceAndComments(statement, 0));
+        std::string semantic_statement_body;
+        if (StartsWithSemantic(statement_body, semantic_statement_body)) {
+            statement_body = semantic_statement_body;
+        }
         std::string drop_view_name;
         bool starts_with_drop_view = StartsWithDropViewStatement(statement_body);
         if (starts_with_drop_view && catalog_statement_seen && executable_since_catalog_mutation) {

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -644,19 +644,49 @@ static bool TransferTemporarySnapshotForPermanentDrop(std::vector<MeasureViewSna
     return false;
 }
 
-static bool TableRefMatchesView(const std::string &table_name, const std::string &view_name) {
-    if (EqualsCaseInsensitive(table_name, view_name)) {
+static bool RestoreShadowedPermanentMetadata(std::vector<MeasureViewSnapshot> &temporary_snapshots,
+                                             const std::string &view_name) {
+    for (auto &snapshot : temporary_snapshots) {
+        if (EqualsCaseInsensitive(snapshot.view_name, view_name)) {
+            void *permanent_snapshot = snapshot.snapshot;
+            snapshot.snapshot = yardstick_snapshot_measure_view(snapshot.view_name.c_str());
+            yardstick_restore_measure_view_snapshot(snapshot.view_name.c_str(), permanent_snapshot);
+            return true;
+        }
+    }
+    return false;
+}
+
+static void RestoreTemporaryMetadata(std::vector<MeasureViewSnapshot> &temporary_snapshots,
+                                     const std::vector<std::string> &view_names) {
+    for (auto &view_name : view_names) {
+        for (auto &snapshot : temporary_snapshots) {
+            if (EqualsCaseInsensitive(snapshot.view_name, view_name)) {
+                void *permanent_snapshot = yardstick_snapshot_measure_view(snapshot.view_name.c_str());
+                yardstick_restore_measure_view_snapshot(snapshot.view_name.c_str(), snapshot.snapshot);
+                snapshot.snapshot = permanent_snapshot;
+                break;
+            }
+        }
+    }
+}
+
+static bool IsUnqualifiedOrTemporarySchemaReference(const std::string &qualified_name);
+
+static bool TableRefMatchesView(const std::string &table_name,
+                                const std::string &view_name,
+                                bool qualified_permanent) {
+    if (!qualified_permanent && EqualsCaseInsensitive(table_name, view_name)) {
         return true;
     }
     if (table_name.size() > view_name.size()) {
         idx_t suffix_start = table_name.size() - view_name.size();
-        return table_name[suffix_start - 1] == '.' &&
-               EqualsCaseInsensitive(table_name.substr(suffix_start), view_name);
-    }
-    if (view_name.size() > table_name.size()) {
-        idx_t suffix_start = view_name.size() - table_name.size();
-        return view_name[suffix_start - 1] == '.' &&
-               EqualsCaseInsensitive(view_name.substr(suffix_start), table_name);
+        if (table_name[suffix_start - 1] != '.' ||
+            !EqualsCaseInsensitive(table_name.substr(suffix_start), view_name)) {
+            return false;
+        }
+        bool temporary_reference = IsUnqualifiedOrTemporarySchemaReference(table_name);
+        return qualified_permanent ? !temporary_reference : temporary_reference;
     }
     return false;
 }
@@ -826,7 +856,7 @@ static std::string LastQualifiedIdentifierPart(const std::string &qualified_name
     return dot_pos == std::string::npos ? qualified_name : qualified_name.substr(dot_pos + 1);
 }
 
-static bool IsUnqualifiedOrTemporarySchemaDrop(const std::string &qualified_name) {
+static bool IsUnqualifiedOrTemporarySchemaReference(const std::string &qualified_name) {
     size_t dot_pos = qualified_name.rfind('.');
     if (dot_pos == std::string::npos) {
         return true;
@@ -840,7 +870,9 @@ static bool IsUnqualifiedOrTemporarySchemaDrop(const std::string &qualified_name
            EqualsCaseInsensitive(schema, "pg_temp");
 }
 
-static bool StatementTextReadsFromView(const std::string &sql, const std::string &view_name) {
+static bool StatementTextReadsFromView(const std::string &sql,
+                                       const std::string &view_name,
+                                       bool qualified_permanent) {
     std::string dollar_quote_end;
     bool in_single_quote = false;
     bool in_double_quote = false;
@@ -929,7 +961,7 @@ static bool StatementTextReadsFromView(const std::string &sql, const std::string
 
         pos = SkipWhitespaceAndComments(sql, pos);
         std::string table_name = ReadQualifiedIdentifier(sql, pos);
-        if (!table_name.empty() && TableRefMatchesView(table_name, view_name)) {
+        if (!table_name.empty() && TableRefMatchesView(table_name, view_name, qualified_permanent)) {
             return true;
         }
     }
@@ -937,28 +969,30 @@ static bool StatementTextReadsFromView(const std::string &sql, const std::string
     return false;
 }
 
-static bool StatementReadsFromView(const std::string &sql, const std::string &view_name) {
+static bool StatementReadsFromView(const std::string &sql,
+                                   const std::string &view_name,
+                                   bool qualified_permanent = false) {
     std::string select_sql = SelectPortionForTableAnalysis(sql);
     YardstickSelectInfo *info = yardstick_parse_select(select_sql.c_str());
     if (!info || info->error) {
         if (info) {
             yardstick_free_select_info(info);
         }
-        return StatementTextReadsFromView(select_sql, view_name);
+        return StatementTextReadsFromView(select_sql, view_name, qualified_permanent);
     }
 
     bool found = false;
     for (idx_t i = 0; i < info->table_count; i++) {
         if (!info->tables[i].is_subquery &&
             info->tables[i].table_name &&
-            TableRefMatchesView(info->tables[i].table_name, view_name)) {
+            TableRefMatchesView(info->tables[i].table_name, view_name, qualified_permanent)) {
             found = true;
             break;
         }
     }
 
     yardstick_free_select_info(info);
-    return found || StatementTextReadsFromView(select_sql, view_name);
+    return found || StatementTextReadsFromView(select_sql, view_name, qualified_permanent);
 }
 
 struct DropViewInfo {
@@ -1004,7 +1038,7 @@ static bool ExtractDropViewInfoFromSql(const std::string &sql, DropViewInfo &dro
 
     drop_view.sql = sql;
     drop_view.view_name = LastQualifiedIdentifierPart(qualified_name);
-    drop_view.targets_temporary_view = IsUnqualifiedOrTemporarySchemaDrop(qualified_name);
+    drop_view.targets_temporary_view = IsUnqualifiedOrTemporarySchemaReference(qualified_name);
     return true;
 }
 
@@ -1237,8 +1271,17 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
             return rewrite_result;
         }
 
+        std::vector<std::string> restored_shadowed_permanent_views;
+        for (auto &view_name : pending_temporary_views) {
+            if (StatementReadsFromView(aggregate_statement, view_name, true) &&
+                RestoreShadowedPermanentMetadata(temporary_snapshots, view_name)) {
+                restored_shadowed_permanent_views.push_back(view_name);
+            }
+        }
+
         YardstickAggregateResult result = yardstick_expand_aggregate(aggregate_statement.c_str());
         if (result.error) {
+            RestoreTemporaryMetadata(temporary_snapshots, restored_shadowed_permanent_views);
             yardstick_free_aggregate_result(result);
             rewritten_statements.push_back(statement);
             if (catalog_statement_seen) {
@@ -1260,6 +1303,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 if (reads_pending_temporary_view) {
                     rewrite_result.error = "TEMPORARY AS MEASURE views cannot be returned directly from a statement batch";
                     yardstick_free_aggregate_result(result);
+                    RestoreTemporaryMetadata(temporary_snapshots, restored_shadowed_permanent_views);
                     cleanup_temporary_measure_views();
                     return rewrite_result;
                 }
@@ -1270,6 +1314,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         } else {
             rewritten_statements.push_back(statement);
         }
+        RestoreTemporaryMetadata(temporary_snapshots, restored_shadowed_permanent_views);
         if (catalog_statement_seen) {
             executable_since_catalog_mutation = true;
         }

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -428,6 +428,71 @@ static std::vector<std::string> SplitSqlStatements(const std::string &sql) {
     return statements;
 }
 
+static bool IsIdentifierChar(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+}
+
+static size_t SkipWhitespaceAndComments(const std::string &sql, size_t pos) {
+    while (pos < sql.size()) {
+        if (std::isspace(static_cast<unsigned char>(sql[pos]))) {
+            pos++;
+            continue;
+        }
+        if (pos + 1 < sql.size() && sql[pos] == '-' && sql[pos + 1] == '-') {
+            pos += 2;
+            while (pos < sql.size() && sql[pos] != '\n') {
+                pos++;
+            }
+            continue;
+        }
+        if (pos + 1 < sql.size() && sql[pos] == '/' && sql[pos + 1] == '*') {
+            pos += 2;
+            while (pos + 1 < sql.size() && !(sql[pos] == '*' && sql[pos + 1] == '/')) {
+                pos++;
+            }
+            pos = std::min(pos + 2, sql.size());
+            continue;
+        }
+        break;
+    }
+    return pos;
+}
+
+static bool ConsumeKeyword(const std::string &sql, size_t &pos, const char *keyword) {
+    size_t keyword_len = strlen(keyword);
+    if (pos + keyword_len > sql.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < keyword_len; i++) {
+        if (std::toupper(static_cast<unsigned char>(sql[pos + i])) != keyword[i]) {
+            return false;
+        }
+    }
+    if (pos + keyword_len < sql.size() && IsIdentifierChar(sql[pos + keyword_len])) {
+        return false;
+    }
+    pos += keyword_len;
+    return true;
+}
+
+static bool StartsWithCreateViewStatement(const std::string &sql) {
+    size_t pos = SkipWhitespaceAndComments(sql, 0);
+    if (!ConsumeKeyword(sql, pos, "CREATE")) {
+        return false;
+    }
+
+    pos = SkipWhitespaceAndComments(sql, pos);
+    if (ConsumeKeyword(sql, pos, "OR")) {
+        pos = SkipWhitespaceAndComments(sql, pos);
+        if (!ConsumeKeyword(sql, pos, "REPLACE")) {
+            return false;
+        }
+        pos = SkipWhitespaceAndComments(sql, pos);
+    }
+
+    return ConsumeKeyword(sql, pos, "VIEW");
+}
+
 struct MeasureRewriteResult {
     bool had_measure_view = false;
     std::string rewritten_sql;
@@ -449,7 +514,8 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
             continue;
         }
 
-        if (!yardstick_has_as_measure(statement.c_str())) {
+        if (!yardstick_has_as_measure(statement.c_str()) ||
+            !StartsWithCreateViewStatement(statement)) {
             rewritten_statements.push_back(statement);
             continue;
         }

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -1015,9 +1015,13 @@ static bool StatementReadsFromView(const std::string &sql,
     }
 
     bool found = false;
+    bool has_subquery = false;
     for (idx_t i = 0; i < info->table_count; i++) {
-        if (!info->tables[i].is_subquery &&
-            info->tables[i].table_name &&
+        if (info->tables[i].is_subquery) {
+            has_subquery = true;
+            continue;
+        }
+        if (info->tables[i].table_name &&
             TableRefMatchesView(info->tables[i].table_name, view_name, qualified_permanent)) {
             found = true;
             break;
@@ -1027,7 +1031,7 @@ static bool StatementReadsFromView(const std::string &sql,
     size_t select_pos = SkipWhitespaceAndComments(select_sql, 0);
     bool starts_with_with = ConsumeKeyword(select_sql, select_pos, "WITH");
     yardstick_free_select_info(info);
-    return found || ((qualified_permanent || starts_with_with) &&
+    return found || ((qualified_permanent || starts_with_with || has_subquery) &&
                      StatementTextReadsFromView(select_sql, view_name, qualified_permanent));
 }
 

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -330,6 +330,130 @@ static bool StartsWithSemantic(const std::string &query, std::string &stripped_q
     return true;
 }
 
+static std::vector<std::string> SplitSqlStatements(const std::string &sql) {
+    std::vector<std::string> statements;
+    size_t statement_start = 0;
+    bool in_single_quote = false;
+    bool in_double_quote = false;
+    bool in_line_comment = false;
+    bool in_block_comment = false;
+
+    for (size_t i = 0; i < sql.size(); i++) {
+        char c = sql[i];
+        char next = i + 1 < sql.size() ? sql[i + 1] : '\0';
+
+        if (in_line_comment) {
+            if (c == '\n') {
+                in_line_comment = false;
+            }
+            continue;
+        }
+
+        if (in_block_comment) {
+            if (c == '*' && next == '/') {
+                in_block_comment = false;
+                i++;
+            }
+            continue;
+        }
+
+        if (in_single_quote) {
+            if (c == '\'' && next == '\'') {
+                i++;
+            } else if (c == '\'') {
+                in_single_quote = false;
+            }
+            continue;
+        }
+
+        if (in_double_quote) {
+            if (c == '"' && next == '"') {
+                i++;
+            } else if (c == '"') {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        if (c == '-' && next == '-') {
+            in_line_comment = true;
+            i++;
+            continue;
+        }
+        if (c == '/' && next == '*') {
+            in_block_comment = true;
+            i++;
+            continue;
+        }
+        if (c == '\'') {
+            in_single_quote = true;
+            continue;
+        }
+        if (c == '"') {
+            in_double_quote = true;
+            continue;
+        }
+
+        if (c == ';') {
+            statements.push_back(sql.substr(statement_start, i - statement_start));
+            statement_start = i + 1;
+        }
+    }
+
+    statements.push_back(sql.substr(statement_start));
+    return statements;
+}
+
+struct MeasureRewriteResult {
+    bool had_measure_view = false;
+    std::string rewritten_sql;
+    std::string error;
+};
+
+static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::string &query) {
+    MeasureRewriteResult rewrite_result;
+    std::vector<std::string> rewritten_statements;
+
+    for (auto statement : SplitSqlStatements(query)) {
+        StringUtil::Trim(statement);
+        if (statement.empty()) {
+            continue;
+        }
+
+        if (!yardstick_has_as_measure(statement.c_str())) {
+            rewritten_statements.push_back(statement);
+            continue;
+        }
+
+        std::string rewritten_statement = RewritePercentileWithinGroup(statement);
+        YardstickCreateViewResult result = yardstick_process_create_view(rewritten_statement.c_str());
+
+        if (result.error) {
+            rewrite_result.error = result.error;
+            yardstick_free_create_view_result(result);
+            return rewrite_result;
+        }
+
+        if (result.is_measure_view) {
+            rewrite_result.had_measure_view = true;
+            rewritten_statements.push_back(RewritePercentileWithinGroup(result.clean_sql));
+        } else {
+            rewritten_statements.push_back(statement);
+        }
+
+        yardstick_free_create_view_result(result);
+    }
+
+    for (idx_t i = 0; i < rewritten_statements.size(); i++) {
+        if (i > 0) {
+            rewrite_result.rewritten_sql += ";\n";
+        }
+        rewrite_result.rewritten_sql += rewritten_statements[i];
+    }
+
+    return rewrite_result;
+}
+
 #if YARDSTICK_TOKEN_PARSE_FN
 // DuckDB main: parse_function receives the post-PEG-failure token tail rather
 // than the query string. Yardstick rewrites queries earlier, in
@@ -353,6 +477,18 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
 
     if (yardstick_drop_measure_view_from_sql(sql_to_check.c_str())) {
         return ParserExtensionParseResult();
+    }
+
+    bool had_measure_rewrite = false;
+    if (yardstick_has_as_measure(sql_to_check.c_str())) {
+        auto measure_rewrite = RewriteMeasureViewsStatementByStatement(sql_to_check);
+        if (!measure_rewrite.error.empty()) {
+            return ParserExtensionParseResult(measure_rewrite.error);
+        }
+        if (measure_rewrite.had_measure_view) {
+            had_measure_rewrite = true;
+            sql_to_check = std::move(measure_rewrite.rewritten_sql);
+        }
     }
 
     // Check for AGGREGATE() function
@@ -398,35 +534,18 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
         yardstick_free_aggregate_result(result);
     }
 
-    // Check for CREATE VIEW with AS MEASURE
-    if (yardstick_has_as_measure(sql_to_check.c_str())) {
-        std::string rewritten_query = RewritePercentileWithinGroup(query);
-        YardstickCreateViewResult result = yardstick_process_create_view(rewritten_query.c_str());
+    if (had_measure_rewrite) {
+        Parser parser;
+        parser.ParseQuery(sql_to_check);
+        auto statements = std::move(parser.statements);
 
-        if (result.error) {
-            string error_msg(result.error);
-            yardstick_free_create_view_result(result);
-            return ParserExtensionParseResult(error_msg);
+        if (statements.empty()) {
+            return ParserExtensionParseResult("CREATE VIEW produced no statements");
         }
 
-        if (result.is_measure_view) {
-            string clean_sql = RewritePercentileWithinGroup(result.clean_sql);
-            yardstick_free_create_view_result(result);
-
-            Parser parser;
-            parser.ParseQuery(clean_sql);
-            auto statements = std::move(parser.statements);
-
-            if (statements.empty()) {
-                return ParserExtensionParseResult("CREATE VIEW produced no statements");
-            }
-
-            return ParserExtensionParseResult(
-                make_uniq_base<ParserExtensionParseData, YardstickParseData>(
-                    std::move(statements[0])));
-        }
-
-        yardstick_free_create_view_result(result);
+        return ParserExtensionParseResult(
+            make_uniq_base<ParserExtensionParseData, YardstickParseData>(
+                std::move(statements[0])));
     }
 
     // Not a yardstick query, let DuckDB handle it
@@ -453,6 +572,22 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
     if (yardstick_drop_measure_view_from_sql(sql_to_check.c_str())) {
         // Catalog cleanup done; let DuckDB handle the actual DROP
         return ParserOverrideResult();
+    }
+
+    bool had_measure_rewrite = false;
+    if (yardstick_has_as_measure(sql_to_check.c_str())) {
+        auto measure_rewrite = RewriteMeasureViewsStatementByStatement(sql_to_check);
+        if (!measure_rewrite.error.empty()) {
+            try {
+                throw ParserException(measure_rewrite.error);
+            } catch (std::exception &e) {
+                return ParserOverrideResult(e);
+            }
+        }
+        if (measure_rewrite.had_measure_view) {
+            had_measure_rewrite = true;
+            sql_to_check = std::move(measure_rewrite.rewritten_sql);
+        }
     }
 
     // Check for AGGREGATE() function
@@ -510,35 +645,14 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
         yardstick_free_aggregate_result(result);
     }
 
-    // Check for CREATE VIEW with AS MEASURE
-    if (yardstick_has_as_measure(sql_to_check.c_str())) {
-        std::string rewritten_query = RewritePercentileWithinGroup(query);
-        YardstickCreateViewResult result = yardstick_process_create_view(rewritten_query.c_str());
-
-        if (result.error) {
-            string error_msg(result.error);
-            yardstick_free_create_view_result(result);
-            try {
-                throw ParserException(error_msg);
-            } catch (std::exception &e) {
-                return ParserOverrideResult(e);
-            }
+    if (had_measure_rewrite) {
+        try {
+            Parser parser;
+            parser.ParseQuery(sql_to_check);
+            return ParserOverrideResult(std::move(parser.statements));
+        } catch (std::exception &e) {
+            return ParserOverrideResult(e);
         }
-
-        if (result.is_measure_view) {
-            string clean_sql = RewritePercentileWithinGroup(result.clean_sql);
-            yardstick_free_create_view_result(result);
-
-            try {
-                Parser parser;
-                parser.ParseQuery(clean_sql);
-                return ParserOverrideResult(std::move(parser.statements));
-            } catch (std::exception &e) {
-                return ParserOverrideResult(e);
-            }
-        }
-
-        yardstick_free_create_view_result(result);
     }
 
     // Not a yardstick query; fall through to DuckDB's native parser

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -978,6 +978,11 @@ static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
     return true;
 }
 
+struct PendingDropView {
+    std::string sql;
+    std::string view_name;
+};
+
 static string EscapeSqlStringLiteral(const string &sql) {
     string escaped_sql;
     for (char c : sql) {
@@ -1013,10 +1018,24 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
     std::vector<MeasureViewSnapshot> temporary_snapshots;
     std::vector<std::string> pending_temporary_views;
     std::vector<std::string> used_temporary_views;
+    std::vector<PendingDropView> deferred_drop_views;
     bool catalog_statement_seen = false;
     bool executable_since_catalog_mutation = false;
     auto cleanup_temporary_measure_views = [&temporary_snapshots]() {
         RestoreMeasureViewSnapshots(temporary_snapshots);
+    };
+    auto apply_deferred_drop_views = [&](const std::string &skip_view_name = "") {
+        for (auto &drop_view : deferred_drop_views) {
+            if (!skip_view_name.empty() &&
+                EqualsCaseInsensitive(drop_view.view_name, skip_view_name)) {
+                continue;
+            }
+            SnapshotAndDropMeasureViewFromSql(drop_view.sql, drop_view.view_name,
+                                              temporary_snapshots, pending_temporary_views,
+                                              used_temporary_views,
+                                              permanent_snapshots);
+        }
+        deferred_drop_views.clear();
     };
 
     for (auto statement : SplitSqlStatements(query)) {
@@ -1044,10 +1063,14 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 return rewrite_result;
             }
             catalog_statement_seen = true;
-            SnapshotAndDropMeasureViewFromSql(statement_body, drop_view_name,
-                                              temporary_snapshots, pending_temporary_views,
-                                              used_temporary_views,
-                                              permanent_snapshots);
+            if (rewrite_result.had_measure_view) {
+                SnapshotAndDropMeasureViewFromSql(statement_body, drop_view_name,
+                                                  temporary_snapshots, pending_temporary_views,
+                                                  used_temporary_views,
+                                                  permanent_snapshots);
+            } else {
+                deferred_drop_views.push_back({statement_body, drop_view_name});
+            }
             executable_since_catalog_mutation = false;
             rewritten_statements.push_back(statement);
             continue;
@@ -1094,6 +1117,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 if (view_name.empty() && result.view_name) {
                     view_name = result.view_name;
                 }
+                apply_deferred_drop_views(view_name);
                 if (is_temporary_measure_view && !view_name.empty()) {
                     if (has_snapshot) {
                         temporary_snapshots.push_back(snapshot);

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -1165,7 +1165,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 deferred_drop_views.push_back(drop_view);
             }
             executable_since_catalog_mutation = false;
-            rewritten_statements.push_back(statement);
+            rewritten_statements.push_back(statement_body);
             continue;
         }
 
@@ -1198,7 +1198,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 apply_deferred_drop_views();
                 if (has_snapshot) {
                     yardstick_free_measure_view_snapshot(snapshot.snapshot);
-                    has_snapshot = false;
+                    snapshot = SnapshotMeasureView(view_name);
                 }
                 preapplied_deferred_drop = true;
             }

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -991,8 +991,11 @@ static bool StatementReadsFromView(const std::string &sql,
         }
     }
 
+    size_t select_pos = SkipWhitespaceAndComments(select_sql, 0);
+    bool starts_with_with = ConsumeKeyword(select_sql, select_pos, "WITH");
     yardstick_free_select_info(info);
-    return found || StatementTextReadsFromView(select_sql, view_name, qualified_permanent);
+    return found || ((qualified_permanent || starts_with_with) &&
+                     StatementTextReadsFromView(select_sql, view_name, qualified_permanent));
 }
 
 struct DropViewInfo {

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -434,6 +434,11 @@ struct MeasureRewriteResult {
     std::string error;
 };
 
+struct AggregateRewriteResult {
+    bool had_aggregate = false;
+    std::string rewritten_sql;
+};
+
 static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::string &query) {
     MeasureRewriteResult rewrite_result;
     std::vector<std::string> rewritten_statements;
@@ -466,6 +471,47 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
         }
 
         yardstick_free_create_view_result(result);
+    }
+
+    for (idx_t i = 0; i < rewritten_statements.size(); i++) {
+        if (i > 0) {
+            rewrite_result.rewritten_sql += ";\n";
+        }
+        rewrite_result.rewritten_sql += rewritten_statements[i];
+    }
+
+    return rewrite_result;
+}
+
+static AggregateRewriteResult RewriteAggregatesStatementByStatement(const std::string &query) {
+    AggregateRewriteResult rewrite_result;
+    std::vector<std::string> rewritten_statements;
+
+    for (auto statement : SplitSqlStatements(query)) {
+        StringUtil::Trim(statement);
+        if (statement.empty()) {
+            continue;
+        }
+
+        if (!yardstick_has_aggregate(statement.c_str())) {
+            rewritten_statements.push_back(statement);
+            continue;
+        }
+
+        YardstickAggregateResult result = yardstick_expand_aggregate(statement.c_str());
+        if (result.error) {
+            yardstick_free_aggregate_result(result);
+            rewritten_statements.push_back(statement);
+            continue;
+        }
+
+        if (result.had_aggregate) {
+            rewrite_result.had_aggregate = true;
+            rewritten_statements.push_back(result.expanded_sql);
+        } else {
+            rewritten_statements.push_back(statement);
+        }
+        yardstick_free_aggregate_result(result);
     }
 
     for (idx_t i = 0; i < rewritten_statements.size(); i++) {
@@ -515,8 +561,15 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
         }
     }
 
+    if (had_measure_rewrite && yardstick_has_aggregate(sql_to_check.c_str())) {
+        auto aggregate_rewrite = RewriteAggregatesStatementByStatement(sql_to_check);
+        if (aggregate_rewrite.had_aggregate) {
+            sql_to_check = std::move(aggregate_rewrite.rewritten_sql);
+        }
+    }
+
     // Check for AGGREGATE() function
-    if (yardstick_has_aggregate(sql_to_check.c_str())) {
+    if (!had_measure_rewrite && yardstick_has_aggregate(sql_to_check.c_str())) {
         YardstickAggregateResult result = yardstick_expand_aggregate(sql_to_check.c_str());
 
         if (result.error) {
@@ -614,8 +667,15 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
         }
     }
 
+    if (had_measure_rewrite && yardstick_has_aggregate(sql_to_check.c_str())) {
+        auto aggregate_rewrite = RewriteAggregatesStatementByStatement(sql_to_check);
+        if (aggregate_rewrite.had_aggregate) {
+            sql_to_check = std::move(aggregate_rewrite.rewritten_sql);
+        }
+    }
+
     // Check for AGGREGATE() function
-    if (yardstick_has_aggregate(sql_to_check.c_str())) {
+    if (!had_measure_rewrite && yardstick_has_aggregate(sql_to_check.c_str())) {
         YardstickAggregateResult result = yardstick_expand_aggregate(sql_to_check.c_str());
 
         if (result.error) {

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -522,6 +522,15 @@ static bool IsTemporaryCreateViewStatement(const std::string &sql) {
            ConsumeKeyword(sql, pos, "TEMP");
 }
 
+static bool StartsWithDropViewStatement(const std::string &sql) {
+    size_t pos = SkipWhitespaceAndComments(sql, 0);
+    if (!ConsumeKeyword(sql, pos, "DROP")) {
+        return false;
+    }
+    pos = SkipWhitespaceAndComments(sql, pos);
+    return ConsumeKeyword(sql, pos, "VIEW");
+}
+
 struct MeasureRewriteResult {
     bool had_measure_view = false;
     bool had_aggregate = false;
@@ -595,6 +604,18 @@ static bool HasMeasureSnapshot(const std::vector<MeasureViewSnapshot> &snapshots
         }
     }
     return false;
+}
+
+static bool TableRefMatchesView(const std::string &table_name, const std::string &view_name) {
+    if (EqualsCaseInsensitive(table_name, view_name)) {
+        return true;
+    }
+    if (table_name.size() <= view_name.size()) {
+        return false;
+    }
+    idx_t suffix_start = table_name.size() - view_name.size();
+    return table_name[suffix_start - 1] == '.' &&
+           EqualsCaseInsensitive(table_name.substr(suffix_start), view_name);
 }
 
 static std::string SelectPortionForTableAnalysis(const std::string &sql) {
@@ -698,6 +719,157 @@ static std::string SelectPortionForTableAnalysis(const std::string &sql) {
     return sql;
 }
 
+static std::string ReadQualifiedIdentifier(const std::string &sql, size_t &pos) {
+    std::string identifier;
+    bool expect_part = true;
+
+    while (pos < sql.size()) {
+        if (!expect_part && sql[pos] == '.') {
+            identifier += '.';
+            pos++;
+            expect_part = true;
+            continue;
+        }
+
+        if (!expect_part) {
+            break;
+        }
+
+        if (sql[pos] == '"') {
+            pos++;
+            std::string part;
+            while (pos < sql.size()) {
+                if (sql[pos] == '"' && pos + 1 < sql.size() && sql[pos + 1] == '"') {
+                    part += '"';
+                    pos += 2;
+                    continue;
+                }
+                if (sql[pos] == '"') {
+                    pos++;
+                    break;
+                }
+                part += sql[pos++];
+            }
+            if (part.empty()) {
+                break;
+            }
+            identifier += part;
+            expect_part = false;
+            continue;
+        }
+
+        if (!IsIdentifierChar(sql[pos])) {
+            break;
+        }
+
+        size_t start = pos;
+        while (pos < sql.size() && IsIdentifierChar(sql[pos])) {
+            pos++;
+        }
+        identifier += sql.substr(start, pos - start);
+        expect_part = false;
+    }
+
+    return identifier;
+}
+
+static bool StatementTextReadsFromView(const std::string &sql, const std::string &view_name) {
+    std::string dollar_quote_end;
+    bool in_single_quote = false;
+    bool in_double_quote = false;
+    bool in_line_comment = false;
+    bool in_block_comment = false;
+
+    for (idx_t i = 0; i < sql.size(); i++) {
+        char c = sql[i];
+        char next = i + 1 < sql.size() ? sql[i + 1] : '\0';
+
+        if (in_line_comment) {
+            if (c == '\n') {
+                in_line_comment = false;
+            }
+            continue;
+        }
+        if (in_block_comment) {
+            if (c == '*' && next == '/') {
+                in_block_comment = false;
+                i++;
+            }
+            continue;
+        }
+        if (!dollar_quote_end.empty()) {
+            if (sql.compare(i, dollar_quote_end.size(), dollar_quote_end) == 0) {
+                i += dollar_quote_end.size() - 1;
+                dollar_quote_end.clear();
+            }
+            continue;
+        }
+        if (in_single_quote) {
+            if (c == '\'' && next == '\'') {
+                i++;
+            } else if (c == '\'') {
+                in_single_quote = false;
+            }
+            continue;
+        }
+        if (in_double_quote) {
+            if (c == '"' && next == '"') {
+                i++;
+            } else if (c == '"') {
+                in_double_quote = false;
+            }
+            continue;
+        }
+
+        if (c == '-' && next == '-') {
+            in_line_comment = true;
+            i++;
+            continue;
+        }
+        if (c == '/' && next == '*') {
+            in_block_comment = true;
+            i++;
+            continue;
+        }
+        if (c == '\'') {
+            in_single_quote = true;
+            continue;
+        }
+        if (c == '"') {
+            in_double_quote = true;
+            continue;
+        }
+        if (c == '$') {
+            idx_t tag_end = i + 1;
+            while (tag_end < sql.size() && sql[tag_end] != '$') {
+                char tag_char = sql[tag_end];
+                if (!std::isalnum(static_cast<unsigned char>(tag_char)) && tag_char != '_') {
+                    break;
+                }
+                tag_end++;
+            }
+            if (tag_end < sql.size() && sql[tag_end] == '$') {
+                dollar_quote_end = sql.substr(i, tag_end - i + 1);
+                i = tag_end;
+                continue;
+            }
+        }
+
+        size_t pos = i;
+        if (!ConsumeKeyword(sql, pos, "FROM") && !ConsumeKeyword(sql, pos, "JOIN")) {
+            continue;
+        }
+
+        pos = SkipWhitespaceAndComments(sql, pos);
+        std::string table_name = ReadQualifiedIdentifier(sql, pos);
+        if (!table_name.empty() && TableRefMatchesView(table_name, view_name)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static bool StatementReadsFromView(const std::string &sql, const std::string &view_name) {
     std::string select_sql = SelectPortionForTableAnalysis(sql);
     YardstickSelectInfo *info = yardstick_parse_select(select_sql.c_str());
@@ -705,34 +877,70 @@ static bool StatementReadsFromView(const std::string &sql, const std::string &vi
         if (info) {
             yardstick_free_select_info(info);
         }
-        return false;
+        return StatementTextReadsFromView(select_sql, view_name);
     }
 
     bool found = false;
     for (idx_t i = 0; i < info->table_count; i++) {
         if (info->tables[i].table_name &&
-            EqualsCaseInsensitive(info->tables[i].table_name, view_name)) {
+            TableRefMatchesView(info->tables[i].table_name, view_name)) {
             found = true;
             break;
         }
     }
 
     yardstick_free_select_info(info);
-    return found;
+    return found || StatementTextReadsFromView(select_sql, view_name);
 }
 
-static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
-                                              std::vector<MeasureViewSnapshot> &temporary_snapshots,
-                                              std::vector<std::string> &pending_temporary_views,
-                                              std::vector<MeasureViewSnapshot> &snapshots) {
+static bool ExtractDropViewNameFromSql(const std::string &sql, std::string &view_name) {
     char *extracted_view_name = yardstick_extract_drop_view_name(sql.c_str());
-    if (!extracted_view_name) {
+    if (extracted_view_name) {
+        view_name = extracted_view_name;
+        yardstick_free(extracted_view_name);
+        return true;
+    }
+
+    size_t pos = SkipWhitespaceAndComments(sql, 0);
+    if (!ConsumeKeyword(sql, pos, "DROP")) {
+        return false;
+    }
+    pos = SkipWhitespaceAndComments(sql, pos);
+    if (!ConsumeKeyword(sql, pos, "VIEW")) {
+        return false;
+    }
+    pos = SkipWhitespaceAndComments(sql, pos);
+    if (ConsumeKeyword(sql, pos, "IF")) {
+        pos = SkipWhitespaceAndComments(sql, pos);
+        if (!ConsumeKeyword(sql, pos, "EXISTS")) {
+            return false;
+        }
+        pos = SkipWhitespaceAndComments(sql, pos);
+    }
+
+    std::string qualified_name = ReadQualifiedIdentifier(sql, pos);
+    if (qualified_name.empty()) {
+        return false;
+    }
+    pos = SkipWhitespaceAndComments(sql, pos);
+    while (pos < sql.size() && sql[pos] == ';') {
+        pos++;
+        pos = SkipWhitespaceAndComments(sql, pos);
+    }
+    if (pos < sql.size()) {
         return false;
     }
 
-    std::string view_name = extracted_view_name;
-    yardstick_free(extracted_view_name);
+    size_t dot_pos = qualified_name.rfind('.');
+    view_name = dot_pos == std::string::npos ? qualified_name : qualified_name.substr(dot_pos + 1);
+    return true;
+}
 
+static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
+                                              const std::string &view_name,
+                                              std::vector<MeasureViewSnapshot> &temporary_snapshots,
+                                              std::vector<std::string> &pending_temporary_views,
+                                              std::vector<MeasureViewSnapshot> &snapshots) {
     if (HasMeasureSnapshot(temporary_snapshots, view_name)) {
         RemoveCaseInsensitive(pending_temporary_views, view_name);
         yardstick_drop_measure_view_from_sql(sql.c_str());
@@ -779,6 +987,8 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
     std::vector<std::string> rewritten_statements;
     std::vector<MeasureViewSnapshot> temporary_snapshots;
     std::vector<std::string> pending_temporary_views;
+    bool catalog_statement_seen = false;
+    bool executable_since_catalog_mutation = false;
     auto cleanup_temporary_measure_views = [&temporary_snapshots]() {
         RestoreMeasureViewSnapshots(temporary_snapshots);
     };
@@ -790,11 +1000,37 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         }
 
         auto statement_body = statement.substr(SkipWhitespaceAndComments(statement, 0));
-        SnapshotAndDropMeasureViewFromSql(statement_body, temporary_snapshots,
-                                          pending_temporary_views, permanent_snapshots);
+        std::string drop_view_name;
+        bool starts_with_drop_view = StartsWithDropViewStatement(statement_body);
+        if (starts_with_drop_view && catalog_statement_seen && executable_since_catalog_mutation) {
+            rewrite_result.error = "AS MEASURE batches cannot apply catalog changes after executable statements";
+            cleanup_temporary_measure_views();
+            return rewrite_result;
+        }
+        if (ExtractDropViewNameFromSql(statement_body, drop_view_name)) {
+            if (catalog_statement_seen && executable_since_catalog_mutation) {
+                rewrite_result.error = "AS MEASURE batches cannot apply catalog changes after executable statements";
+                cleanup_temporary_measure_views();
+                return rewrite_result;
+            }
+            catalog_statement_seen = true;
+            SnapshotAndDropMeasureViewFromSql(statement_body, drop_view_name,
+                                              temporary_snapshots, pending_temporary_views,
+                                              permanent_snapshots);
+            executable_since_catalog_mutation = false;
+            rewritten_statements.push_back(statement);
+            continue;
+        }
 
         if (yardstick_has_as_measure(statement_body.c_str()) &&
             StartsWithCreateViewStatement(statement_body)) {
+            if (catalog_statement_seen && executable_since_catalog_mutation) {
+                rewrite_result.error = "AS MEASURE batches cannot apply catalog changes after executable statements";
+                cleanup_temporary_measure_views();
+                return rewrite_result;
+            }
+            catalog_statement_seen = true;
+
             std::string rewritten_statement = RewritePercentileWithinGroup(statement_body);
             bool is_temporary_measure_view = IsTemporaryCreateViewStatement(statement_body);
             std::string view_name;
@@ -823,6 +1059,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
 
             if (result.is_measure_view) {
                 rewrite_result.had_measure_view = true;
+                executable_since_catalog_mutation = false;
                 if (view_name.empty() && result.view_name) {
                     view_name = result.view_name;
                 }
@@ -856,6 +1093,9 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
 
         if (!yardstick_has_aggregate(aggregate_statement.c_str())) {
             rewritten_statements.push_back(statement);
+            if (catalog_statement_seen) {
+                executable_since_catalog_mutation = true;
+            }
             continue;
         }
 
@@ -863,13 +1103,18 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         if (result.error) {
             yardstick_free_aggregate_result(result);
             rewritten_statements.push_back(statement);
+            if (catalog_statement_seen) {
+                executable_since_catalog_mutation = true;
+            }
             continue;
         }
 
         if (result.had_aggregate) {
             rewrite_result.had_aggregate = true;
+            bool reads_pending_temporary_view = false;
             for (auto it = pending_temporary_views.begin(); it != pending_temporary_views.end();) {
                 if (StatementReadsFromView(aggregate_statement, *it)) {
+                    reads_pending_temporary_view = true;
                     it = pending_temporary_views.erase(it);
                 } else {
                     ++it;
@@ -877,12 +1122,21 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
             }
             string expanded_sql(result.expanded_sql);
             if (ParsesAsSingleSelect(expanded_sql)) {
+                if (reads_pending_temporary_view) {
+                    rewrite_result.error = "TEMPORARY AS MEASURE views cannot be returned directly from a statement batch";
+                    yardstick_free_aggregate_result(result);
+                    cleanup_temporary_measure_views();
+                    return rewrite_result;
+                }
                 rewritten_statements.push_back(WrapYardstickSelect(expanded_sql));
             } else {
                 rewritten_statements.push_back(expanded_sql);
             }
         } else {
             rewritten_statements.push_back(statement);
+        }
+        if (catalog_statement_seen) {
+            executable_since_catalog_mutation = true;
         }
         yardstick_free_aggregate_result(result);
     }

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -552,7 +552,70 @@ static MeasureViewSnapshot SnapshotMeasureView(const std::string &view_name) {
     return {view_name, yardstick_snapshot_measure_view(view_name.c_str())};
 }
 
+static bool EqualsCaseInsensitive(const std::string &left, const std::string &right) {
+    if (left.size() != right.size()) {
+        return false;
+    }
+    for (idx_t i = 0; i < left.size(); i++) {
+        if (std::tolower(static_cast<unsigned char>(left[i])) !=
+            std::tolower(static_cast<unsigned char>(right[i]))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool ContainsIdentifier(const std::string &sql, const std::string &identifier) {
+    if (identifier.empty() || sql.size() < identifier.size()) {
+        return false;
+    }
+
+    for (idx_t i = 0; i + identifier.size() <= sql.size(); i++) {
+        bool matches = true;
+        for (idx_t j = 0; j < identifier.size(); j++) {
+            if (std::tolower(static_cast<unsigned char>(sql[i + j])) !=
+                std::tolower(static_cast<unsigned char>(identifier[j]))) {
+                matches = false;
+                break;
+            }
+        }
+        if (!matches) {
+            continue;
+        }
+
+        bool left_boundary = i == 0 || !IsIdentifierChar(sql[i - 1]);
+        idx_t end = i + identifier.size();
+        bool right_boundary = end >= sql.size() || !IsIdentifierChar(sql[end]);
+        if (left_boundary && right_boundary) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool RemoveCaseInsensitive(std::vector<std::string> &values, const std::string &value) {
+    for (auto it = values.begin(); it != values.end(); ++it) {
+        if (EqualsCaseInsensitive(*it, value)) {
+            values.erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool HasTemporarySnapshot(const std::vector<MeasureViewSnapshot> &snapshots,
+                                 const std::string &view_name) {
+    for (auto &snapshot : snapshots) {
+        if (EqualsCaseInsensitive(snapshot.view_name, view_name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
+                                              const std::vector<MeasureViewSnapshot> &temporary_snapshots,
+                                              std::vector<std::string> &pending_temporary_views,
                                               std::vector<MeasureViewSnapshot> &snapshots) {
     char *extracted_view_name = yardstick_extract_drop_view_name(sql.c_str());
     if (!extracted_view_name) {
@@ -561,6 +624,13 @@ static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
 
     std::string view_name = extracted_view_name;
     yardstick_free(extracted_view_name);
+
+    if (HasTemporarySnapshot(temporary_snapshots, view_name)) {
+        RemoveCaseInsensitive(pending_temporary_views, view_name);
+        yardstick_drop_measure_view_from_sql(sql.c_str());
+        return true;
+    }
+
     snapshots.push_back(SnapshotMeasureView(view_name));
     yardstick_drop_measure_view_from_sql(sql.c_str());
     return true;
@@ -599,6 +669,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
     MeasureRewriteResult rewrite_result;
     std::vector<std::string> rewritten_statements;
     std::vector<MeasureViewSnapshot> temporary_snapshots;
+    std::vector<std::string> pending_temporary_views;
     auto cleanup_temporary_measure_views = [&temporary_snapshots]() {
         RestoreMeasureViewSnapshots(temporary_snapshots);
     };
@@ -610,7 +681,8 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         }
 
         auto statement_body = statement.substr(SkipWhitespaceAndComments(statement, 0));
-        SnapshotAndDropMeasureViewFromSql(statement_body, permanent_snapshots);
+        SnapshotAndDropMeasureViewFromSql(statement_body, temporary_snapshots,
+                                          pending_temporary_views, permanent_snapshots);
 
         if (yardstick_has_as_measure(statement_body.c_str()) &&
             StartsWithCreateViewStatement(statement_body)) {
@@ -648,6 +720,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 if (is_temporary_measure_view && !view_name.empty()) {
                     if (has_snapshot) {
                         temporary_snapshots.push_back(snapshot);
+                        pending_temporary_views.push_back(view_name);
                         has_snapshot = false;
                     }
                 } else if (has_snapshot) {
@@ -686,6 +759,13 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
 
         if (result.had_aggregate) {
             rewrite_result.had_aggregate = true;
+            for (auto it = pending_temporary_views.begin(); it != pending_temporary_views.end();) {
+                if (ContainsIdentifier(aggregate_statement, *it)) {
+                    it = pending_temporary_views.erase(it);
+                } else {
+                    ++it;
+                }
+            }
             string expanded_sql(result.expanded_sql);
             if (ParsesAsSingleSelect(expanded_sql)) {
                 rewritten_statements.push_back(WrapYardstickSelect(expanded_sql));
@@ -698,7 +778,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         yardstick_free_aggregate_result(result);
     }
 
-    if (!temporary_snapshots.empty() && !rewrite_result.had_aggregate) {
+    if (!pending_temporary_views.empty()) {
         rewrite_result.error = "TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()";
         cleanup_temporary_measure_views();
         return rewrite_result;

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -514,6 +514,8 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
             continue;
         }
 
+        yardstick_drop_measure_view_from_sql(statement.c_str());
+
         if (!yardstick_has_as_measure(statement.c_str()) ||
             !StartsWithCreateViewStatement(statement)) {
             rewritten_statements.push_back(statement);

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -593,6 +593,12 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
         yardstick_free_aggregate_result(result);
     }
 
+    if (!temporary_measure_views.empty() && !rewrite_result.had_aggregate) {
+        rewrite_result.error = "TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()";
+        cleanup_temporary_measure_views();
+        return rewrite_result;
+    }
+
     for (idx_t i = 0; i < rewritten_statements.size(); i++) {
         if (i > 0) {
             rewrite_result.rewritten_sql += ";\n";

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -580,13 +580,16 @@ static bool EqualsCaseInsensitive(const std::string &left, const std::string &ri
 }
 
 static bool RemoveCaseInsensitive(std::vector<std::string> &values, const std::string &value) {
-    for (auto it = values.begin(); it != values.end(); ++it) {
+    bool removed = false;
+    for (auto it = values.begin(); it != values.end();) {
         if (EqualsCaseInsensitive(*it, value)) {
-            values.erase(it);
-            return true;
+            it = values.erase(it);
+            removed = true;
+        } else {
+            ++it;
         }
     }
-    return false;
+    return removed;
 }
 
 static bool ContainsCaseInsensitive(const std::vector<std::string> &values, const std::string &value) {
@@ -600,14 +603,21 @@ static bool ContainsCaseInsensitive(const std::vector<std::string> &values, cons
 
 static bool RestoreAndRemoveTemporarySnapshot(std::vector<MeasureViewSnapshot> &snapshots,
                                               const std::string &view_name) {
-    for (auto it = snapshots.begin(); it != snapshots.end(); ++it) {
+    bool restored = false;
+    for (auto it = snapshots.begin(); it != snapshots.end();) {
         if (EqualsCaseInsensitive(it->view_name, view_name)) {
-            yardstick_restore_measure_view_snapshot(it->view_name.c_str(), it->snapshot);
-            snapshots.erase(it);
-            return true;
+            if (!restored) {
+                yardstick_restore_measure_view_snapshot(it->view_name.c_str(), it->snapshot);
+                restored = true;
+            } else {
+                yardstick_free_measure_view_snapshot(it->snapshot);
+            }
+            it = snapshots.erase(it);
+        } else {
+            ++it;
         }
     }
-    return false;
+    return restored;
 }
 
 static bool HasMeasureSnapshot(const std::vector<MeasureViewSnapshot> &snapshots,

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -47,6 +47,7 @@ extern "C" {
     char *yardstick_extract_view_name(const char *sql);
     char *yardstick_extract_drop_view_name(const char *sql);
     void *yardstick_snapshot_measure_view(const char *view_name);
+    void *yardstick_empty_measure_view_snapshot();
     void yardstick_restore_measure_view_snapshot(const char *view_name, void *snapshot);
     void yardstick_free_measure_view_snapshot(void *snapshot);
     YardstickCreateViewResult yardstick_process_create_view(const char *sql);
@@ -630,6 +631,19 @@ static bool HasMeasureSnapshot(const std::vector<MeasureViewSnapshot> &snapshots
     return false;
 }
 
+static bool TransferTemporarySnapshotForPermanentDrop(std::vector<MeasureViewSnapshot> &temporary_snapshots,
+                                                      const std::string &view_name,
+                                                      std::vector<MeasureViewSnapshot> &rollback_snapshots) {
+    for (auto &snapshot : temporary_snapshots) {
+        if (EqualsCaseInsensitive(snapshot.view_name, view_name)) {
+            rollback_snapshots.push_back({snapshot.view_name, snapshot.snapshot});
+            snapshot.snapshot = yardstick_empty_measure_view_snapshot();
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool TableRefMatchesView(const std::string &table_name, const std::string &view_name) {
     if (EqualsCaseInsensitive(table_name, view_name)) {
         return true;
@@ -807,6 +821,25 @@ static std::string ReadQualifiedIdentifier(const std::string &sql, size_t &pos) 
     return identifier;
 }
 
+static std::string LastQualifiedIdentifierPart(const std::string &qualified_name) {
+    size_t dot_pos = qualified_name.rfind('.');
+    return dot_pos == std::string::npos ? qualified_name : qualified_name.substr(dot_pos + 1);
+}
+
+static bool IsUnqualifiedOrTemporarySchemaDrop(const std::string &qualified_name) {
+    size_t dot_pos = qualified_name.rfind('.');
+    if (dot_pos == std::string::npos) {
+        return true;
+    }
+
+    std::string qualifier = qualified_name.substr(0, dot_pos);
+    size_t schema_dot = qualifier.rfind('.');
+    std::string schema = schema_dot == std::string::npos ? qualifier : qualifier.substr(schema_dot + 1);
+    return EqualsCaseInsensitive(schema, "temp") ||
+           EqualsCaseInsensitive(schema, "temporary") ||
+           EqualsCaseInsensitive(schema, "pg_temp");
+}
+
 static bool StatementTextReadsFromView(const std::string &sql, const std::string &view_name) {
     std::string dollar_quote_end;
     bool in_single_quote = false;
@@ -928,14 +961,13 @@ static bool StatementReadsFromView(const std::string &sql, const std::string &vi
     return found || StatementTextReadsFromView(select_sql, view_name);
 }
 
-static bool ExtractDropViewNameFromSql(const std::string &sql, std::string &view_name) {
-    char *extracted_view_name = yardstick_extract_drop_view_name(sql.c_str());
-    if (extracted_view_name) {
-        view_name = extracted_view_name;
-        yardstick_free(extracted_view_name);
-        return true;
-    }
+struct DropViewInfo {
+    std::string sql;
+    std::string view_name;
+    bool targets_temporary_view = true;
+};
 
+static bool ExtractDropViewInfoFromSql(const std::string &sql, DropViewInfo &drop_view) {
     size_t pos = SkipWhitespaceAndComments(sql, 0);
     if (!ConsumeKeyword(sql, pos, "DROP")) {
         return false;
@@ -970,22 +1002,28 @@ static bool ExtractDropViewNameFromSql(const std::string &sql, std::string &view
         return false;
     }
 
-    size_t dot_pos = qualified_name.rfind('.');
-    view_name = dot_pos == std::string::npos ? qualified_name : qualified_name.substr(dot_pos + 1);
+    drop_view.sql = sql;
+    drop_view.view_name = LastQualifiedIdentifierPart(qualified_name);
+    drop_view.targets_temporary_view = IsUnqualifiedOrTemporarySchemaDrop(qualified_name);
     return true;
 }
 
 static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
                                               const std::string &view_name,
+                                              bool targets_temporary_view,
                                               std::vector<MeasureViewSnapshot> &temporary_snapshots,
                                               std::vector<std::string> &pending_temporary_views,
                                               std::vector<std::string> &used_temporary_views,
                                               std::vector<MeasureViewSnapshot> &snapshots) {
-    if (HasMeasureSnapshot(temporary_snapshots, view_name)) {
+    if (targets_temporary_view && HasMeasureSnapshot(temporary_snapshots, view_name)) {
         RemoveCaseInsensitive(pending_temporary_views, view_name);
         RemoveCaseInsensitive(used_temporary_views, view_name);
         yardstick_drop_measure_view_from_sql(sql.c_str());
         RestoreAndRemoveTemporarySnapshot(temporary_snapshots, view_name);
+        return true;
+    }
+    if (!targets_temporary_view &&
+        TransferTemporarySnapshotForPermanentDrop(temporary_snapshots, view_name, snapshots)) {
         return true;
     }
 
@@ -993,11 +1031,6 @@ static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
     yardstick_drop_measure_view_from_sql(sql.c_str());
     return true;
 }
-
-struct PendingDropView {
-    std::string sql;
-    std::string view_name;
-};
 
 static string EscapeSqlStringLiteral(const string &sql) {
     string escaped_sql;
@@ -1034,7 +1067,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
     std::vector<MeasureViewSnapshot> temporary_snapshots;
     std::vector<std::string> pending_temporary_views;
     std::vector<std::string> used_temporary_views;
-    std::vector<PendingDropView> deferred_drop_views;
+    std::vector<DropViewInfo> deferred_drop_views;
     bool catalog_statement_seen = false;
     bool executable_since_catalog_mutation = false;
     auto cleanup_temporary_measure_views = [&temporary_snapshots]() {
@@ -1047,6 +1080,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
                 continue;
             }
             SnapshotAndDropMeasureViewFromSql(drop_view.sql, drop_view.view_name,
+                                              drop_view.targets_temporary_view,
                                               temporary_snapshots, pending_temporary_views,
                                               used_temporary_views,
                                               permanent_snapshots);
@@ -1073,14 +1107,14 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         if (StartsWithSemantic(statement_body, semantic_statement_body)) {
             statement_body = semantic_statement_body;
         }
-        std::string drop_view_name;
+        DropViewInfo drop_view;
         bool starts_with_drop_view = StartsWithDropViewStatement(statement_body);
         if (starts_with_drop_view && catalog_statement_seen && executable_since_catalog_mutation) {
             rewrite_result.error = "AS MEASURE batches cannot apply catalog changes after executable statements";
             cleanup_temporary_measure_views();
             return rewrite_result;
         }
-        if (ExtractDropViewNameFromSql(statement_body, drop_view_name)) {
+        if (ExtractDropViewInfoFromSql(statement_body, drop_view)) {
             if (catalog_statement_seen && executable_since_catalog_mutation) {
                 rewrite_result.error = "AS MEASURE batches cannot apply catalog changes after executable statements";
                 cleanup_temporary_measure_views();
@@ -1088,12 +1122,13 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
             }
             catalog_statement_seen = true;
             if (rewrite_result.had_measure_view) {
-                SnapshotAndDropMeasureViewFromSql(statement_body, drop_view_name,
+                SnapshotAndDropMeasureViewFromSql(statement_body, drop_view.view_name,
+                                                  drop_view.targets_temporary_view,
                                                   temporary_snapshots, pending_temporary_views,
                                                   used_temporary_views,
                                                   permanent_snapshots);
             } else {
-                deferred_drop_views.push_back({statement_body, drop_view_name});
+                deferred_drop_views.push_back(drop_view);
             }
             executable_since_catalog_mutation = false;
             rewritten_statements.push_back(statement);

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -551,6 +551,33 @@ static MeasureViewSnapshot SnapshotMeasureView(const std::string &view_name) {
     return {view_name, yardstick_snapshot_measure_view(view_name.c_str())};
 }
 
+static string EscapeSqlStringLiteral(const string &sql) {
+    string escaped_sql;
+    for (char c : sql) {
+        if (c == '\'') {
+            escaped_sql += "''";
+        } else {
+            escaped_sql += c;
+        }
+    }
+    return escaped_sql;
+}
+
+static string WrapYardstickSelect(const string &sql) {
+    return "SELECT * FROM yardstick('" + EscapeSqlStringLiteral(sql) + "')";
+}
+
+static bool ParsesAsSingleSelect(const string &sql) {
+    Parser parser;
+    try {
+        parser.ParseQuery(sql);
+    } catch (...) {
+        return false;
+    }
+    return parser.statements.size() == 1 &&
+           parser.statements[0]->type == StatementType::SELECT_STATEMENT;
+}
+
 static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         const std::string &query,
         std::vector<MeasureViewSnapshot> &permanent_snapshots) {
@@ -638,7 +665,12 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
 
         if (result.had_aggregate) {
             rewrite_result.had_aggregate = true;
-            rewritten_statements.push_back(result.expanded_sql);
+            string expanded_sql(result.expanded_sql);
+            if (ParsesAsSingleSelect(expanded_sql)) {
+                rewritten_statements.push_back(WrapYardstickSelect(expanded_sql));
+            } else {
+                rewritten_statements.push_back(expanded_sql);
+            }
         } else {
             rewritten_statements.push_back(statement);
         }
@@ -715,18 +747,8 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
             string expanded_sql(result.expanded_sql);
             yardstick_free_aggregate_result(result);
 
-            // Escape single quotes for embedding in string literal
-            string escaped_sql;
-            for (char c : expanded_sql) {
-                if (c == '\'') {
-                    escaped_sql += "''";
-                } else {
-                    escaped_sql += c;
-                }
-            }
-
             // Wrap in table function call
-            string wrapper_sql = "SELECT * FROM yardstick('" + escaped_sql + "')";
+            string wrapper_sql = WrapYardstickSelect(expanded_sql);
 
             Parser parser;
             parser.ParseQuery(wrapper_sql);
@@ -845,16 +867,7 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
                              validation_parser.statements[0]->type == StatementType::SELECT_STATEMENT;
 
             if (is_select) {
-                string escaped_sql;
-                for (char c : expanded_sql) {
-                    if (c == '\'') {
-                        escaped_sql += "''";
-                    } else {
-                        escaped_sql += c;
-                    }
-                }
-
-                string wrapper_sql = "SELECT * FROM yardstick('" + escaped_sql + "')";
+                string wrapper_sql = WrapYardstickSelect(expanded_sql);
                 Parser parser;
                 parser.ParseQuery(wrapper_sql);
                 return ParserOverrideResult(std::move(parser.statements));

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -333,6 +333,7 @@ static bool StartsWithSemantic(const std::string &query, std::string &stripped_q
 static std::vector<std::string> SplitSqlStatements(const std::string &sql) {
     std::vector<std::string> statements;
     size_t statement_start = 0;
+    std::string dollar_quote_end;
     bool in_single_quote = false;
     bool in_double_quote = false;
     bool in_line_comment = false;
@@ -353,6 +354,14 @@ static std::vector<std::string> SplitSqlStatements(const std::string &sql) {
             if (c == '*' && next == '/') {
                 in_block_comment = false;
                 i++;
+            }
+            continue;
+        }
+
+        if (!dollar_quote_end.empty()) {
+            if (sql.compare(i, dollar_quote_end.size(), dollar_quote_end) == 0) {
+                i += dollar_quote_end.size() - 1;
+                dollar_quote_end.clear();
             }
             continue;
         }
@@ -392,6 +401,21 @@ static std::vector<std::string> SplitSqlStatements(const std::string &sql) {
         if (c == '"') {
             in_double_quote = true;
             continue;
+        }
+        if (c == '$') {
+            size_t tag_end = i + 1;
+            while (tag_end < sql.size() && sql[tag_end] != '$') {
+                char tag_char = sql[tag_end];
+                if (!std::isalnum(static_cast<unsigned char>(tag_char)) && tag_char != '_') {
+                    break;
+                }
+                tag_end++;
+            }
+            if (tag_end < sql.size() && sql[tag_end] == '$') {
+                dollar_quote_end = sql.substr(i, tag_end - i + 1);
+                i = tag_end;
+                continue;
+            }
         }
 
         if (c == ';') {

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -1204,6 +1204,7 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
         if (result.error) {
             string error_msg(result.error);
             yardstick_free_aggregate_result(result);
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             return ParserExtensionParseResult(error_msg);
         }
 
@@ -1219,9 +1220,11 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
             auto statements = std::move(parser.statements);
 
             if (statements.empty()) {
+                RestoreMeasureViewSnapshots(permanent_snapshots);
                 return ParserExtensionParseResult("Table function wrapper produced no statements");
             }
 
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             return ParserExtensionParseResult(
                 make_uniq_base<ParserExtensionParseData, YardstickParseData>(
                     std::move(statements[0])));
@@ -1251,7 +1254,7 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
                 std::move(statements[0])));
     }
 
-    FreeMeasureViewSnapshots(permanent_snapshots);
+    RestoreMeasureViewSnapshots(permanent_snapshots);
 
     // Not a yardstick query, let DuckDB handle it
     return ParserExtensionParseResult();
@@ -1306,6 +1309,7 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
             // (e.g. DuckDB's built-in list aggregate function). Fall through to
             // the native parser in case it can handle the query.
             yardstick_free_aggregate_result(result);
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             return ParserOverrideResult();
         }
 
@@ -1320,6 +1324,7 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
             try {
                 validation_parser.ParseQuery(expanded_sql);
             } catch (...) {
+                RestoreMeasureViewSnapshots(permanent_snapshots);
                 return ParserOverrideResult();
             }
 
@@ -1334,9 +1339,11 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
                 string wrapper_sql = WrapYardstickSelect(expanded_sql);
                 Parser parser;
                 parser.ParseQuery(wrapper_sql);
+                RestoreMeasureViewSnapshots(permanent_snapshots);
                 return ParserOverrideResult(std::move(parser.statements));
             }
 
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             return ParserOverrideResult(std::move(validation_parser.statements));
         }
 
@@ -1355,7 +1362,7 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
         }
     }
 
-    FreeMeasureViewSnapshots(permanent_snapshots);
+    RestoreMeasureViewSnapshots(permanent_snapshots);
 
     // Not a yardstick query; fall through to DuckDB's native parser
     return ParserOverrideResult();

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -44,6 +44,10 @@ extern "C" {
     bool yardstick_has_as_measure(const char *sql);
     bool yardstick_has_aggregate(const char *sql);
     bool yardstick_drop_measure_view_from_sql(const char *sql);
+    char *yardstick_extract_view_name(const char *sql);
+    void *yardstick_snapshot_measure_view(const char *view_name);
+    void yardstick_restore_measure_view_snapshot(const char *view_name, void *snapshot);
+    void yardstick_free_measure_view_snapshot(void *snapshot);
     YardstickCreateViewResult yardstick_process_create_view(const char *sql);
     YardstickAggregateResult yardstick_expand_aggregate(const char *sql);
     void yardstick_free(char *ptr);
@@ -524,16 +528,37 @@ struct MeasureRewriteResult {
     std::string error;
 };
 
-static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::string &query) {
+struct MeasureViewSnapshot {
+    std::string view_name;
+    void *snapshot = nullptr;
+};
+
+static void RestoreMeasureViewSnapshots(std::vector<MeasureViewSnapshot> &snapshots) {
+    for (auto it = snapshots.rbegin(); it != snapshots.rend(); ++it) {
+        yardstick_restore_measure_view_snapshot(it->view_name.c_str(), it->snapshot);
+    }
+    snapshots.clear();
+}
+
+static void FreeMeasureViewSnapshots(std::vector<MeasureViewSnapshot> &snapshots) {
+    for (auto &snapshot : snapshots) {
+        yardstick_free_measure_view_snapshot(snapshot.snapshot);
+    }
+    snapshots.clear();
+}
+
+static MeasureViewSnapshot SnapshotMeasureView(const std::string &view_name) {
+    return {view_name, yardstick_snapshot_measure_view(view_name.c_str())};
+}
+
+static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
+        const std::string &query,
+        std::vector<MeasureViewSnapshot> &permanent_snapshots) {
     MeasureRewriteResult rewrite_result;
     std::vector<std::string> rewritten_statements;
-    std::vector<std::string> temporary_measure_views;
-    auto cleanup_temporary_measure_views = [&temporary_measure_views]() {
-        for (auto it = temporary_measure_views.rbegin(); it != temporary_measure_views.rend(); ++it) {
-            std::string drop_sql = "DROP VIEW " + *it;
-            yardstick_drop_measure_view_from_sql(drop_sql.c_str());
-        }
-        temporary_measure_views.clear();
+    std::vector<MeasureViewSnapshot> temporary_snapshots;
+    auto cleanup_temporary_measure_views = [&temporary_snapshots]() {
+        RestoreMeasureViewSnapshots(temporary_snapshots);
     };
 
     for (auto statement : SplitSqlStatements(query)) {
@@ -549,25 +574,52 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
             StartsWithCreateViewStatement(statement_body)) {
             std::string rewritten_statement = RewritePercentileWithinGroup(statement_body);
             bool is_temporary_measure_view = IsTemporaryCreateViewStatement(statement_body);
+            std::string view_name;
+            char *extracted_view_name = yardstick_extract_view_name(rewritten_statement.c_str());
+            if (extracted_view_name) {
+                view_name = extracted_view_name;
+                yardstick_free(extracted_view_name);
+            }
+            MeasureViewSnapshot snapshot;
+            bool has_snapshot = false;
+            if (!view_name.empty()) {
+                snapshot = SnapshotMeasureView(view_name);
+                has_snapshot = true;
+            }
             YardstickCreateViewResult result = yardstick_process_create_view(rewritten_statement.c_str());
 
             if (result.error) {
                 rewrite_result.error = result.error;
                 yardstick_free_create_view_result(result);
+                if (has_snapshot) {
+                    yardstick_free_measure_view_snapshot(snapshot.snapshot);
+                }
                 cleanup_temporary_measure_views();
                 return rewrite_result;
             }
 
             if (result.is_measure_view) {
                 rewrite_result.had_measure_view = true;
-                if (is_temporary_measure_view && result.view_name) {
-                    temporary_measure_views.emplace_back(result.view_name);
+                if (view_name.empty() && result.view_name) {
+                    view_name = result.view_name;
+                }
+                if (is_temporary_measure_view && !view_name.empty()) {
+                    if (has_snapshot) {
+                        temporary_snapshots.push_back(snapshot);
+                        has_snapshot = false;
+                    }
+                } else if (has_snapshot) {
+                    permanent_snapshots.push_back(snapshot);
+                    has_snapshot = false;
                 }
                 rewritten_statements.push_back(RewritePercentileWithinGroup(result.clean_sql));
             } else {
                 rewritten_statements.push_back(statement);
             }
 
+            if (has_snapshot) {
+                yardstick_free_measure_view_snapshot(snapshot.snapshot);
+            }
             yardstick_free_create_view_result(result);
             continue;
         }
@@ -593,7 +645,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(const std::s
         yardstick_free_aggregate_result(result);
     }
 
-    if (!temporary_measure_views.empty() && !rewrite_result.had_aggregate) {
+    if (!temporary_snapshots.empty() && !rewrite_result.had_aggregate) {
         rewrite_result.error = "TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()";
         cleanup_temporary_measure_views();
         return rewrite_result;
@@ -636,9 +688,11 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
     }
 
     bool had_measure_rewrite = false;
+    std::vector<MeasureViewSnapshot> permanent_snapshots;
     if (yardstick_has_as_measure(sql_to_check.c_str())) {
-        auto measure_rewrite = RewriteMeasureViewsStatementByStatement(sql_to_check);
+        auto measure_rewrite = RewriteMeasureViewsStatementByStatement(sql_to_check, permanent_snapshots);
         if (!measure_rewrite.error.empty()) {
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             return ParserExtensionParseResult(measure_rewrite.error);
         }
         if (measure_rewrite.had_measure_view) {
@@ -692,17 +746,26 @@ ParserExtensionParseResult yardstick_parse(ParserExtensionInfo *,
 
     if (had_measure_rewrite) {
         Parser parser;
-        parser.ParseQuery(sql_to_check);
+        try {
+            parser.ParseQuery(sql_to_check);
+        } catch (std::exception &e) {
+            RestoreMeasureViewSnapshots(permanent_snapshots);
+            return ParserExtensionParseResult(e.what());
+        }
         auto statements = std::move(parser.statements);
 
         if (statements.empty()) {
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             return ParserExtensionParseResult("CREATE VIEW produced no statements");
         }
 
+        FreeMeasureViewSnapshots(permanent_snapshots);
         return ParserExtensionParseResult(
             make_uniq_base<ParserExtensionParseData, YardstickParseData>(
                 std::move(statements[0])));
     }
+
+    FreeMeasureViewSnapshots(permanent_snapshots);
 
     // Not a yardstick query, let DuckDB handle it
     return ParserExtensionParseResult();
@@ -731,9 +794,11 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
     }
 
     bool had_measure_rewrite = false;
+    std::vector<MeasureViewSnapshot> permanent_snapshots;
     if (yardstick_has_as_measure(sql_to_check.c_str())) {
-        auto measure_rewrite = RewriteMeasureViewsStatementByStatement(sql_to_check);
+        auto measure_rewrite = RewriteMeasureViewsStatementByStatement(sql_to_check, permanent_snapshots);
         if (!measure_rewrite.error.empty()) {
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             try {
                 throw ParserException(measure_rewrite.error);
             } catch (std::exception &e) {
@@ -805,11 +870,15 @@ ParserOverrideResult yardstick_parser_override(ParserExtensionInfo *,
         try {
             Parser parser;
             parser.ParseQuery(sql_to_check);
+            FreeMeasureViewSnapshots(permanent_snapshots);
             return ParserOverrideResult(std::move(parser.statements));
         } catch (std::exception &e) {
+            RestoreMeasureViewSnapshots(permanent_snapshots);
             return ParserOverrideResult(e);
         }
     }
+
+    FreeMeasureViewSnapshots(permanent_snapshots);
 
     // Not a yardstick query; fall through to DuckDB's native parser
     return ParserOverrideResult();

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -531,6 +531,11 @@ static bool StartsWithDropViewStatement(const std::string &sql) {
     return ConsumeKeyword(sql, pos, "VIEW");
 }
 
+static bool StartsWithSelectStatement(const std::string &sql) {
+    size_t pos = SkipWhitespaceAndComments(sql, 0);
+    return ConsumeKeyword(sql, pos, "SELECT");
+}
+
 struct MeasureRewriteResult {
     bool had_measure_view = false;
     bool had_aggregate = false;
@@ -584,6 +589,15 @@ static bool RemoveCaseInsensitive(std::vector<std::string> &values, const std::s
     return false;
 }
 
+static bool ContainsCaseInsensitive(const std::vector<std::string> &values, const std::string &value) {
+    for (auto &candidate : values) {
+        if (EqualsCaseInsensitive(candidate, value)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static bool RestoreAndRemoveTemporarySnapshot(std::vector<MeasureViewSnapshot> &snapshots,
                                               const std::string &view_name) {
     for (auto it = snapshots.begin(); it != snapshots.end(); ++it) {
@@ -610,12 +624,17 @@ static bool TableRefMatchesView(const std::string &table_name, const std::string
     if (EqualsCaseInsensitive(table_name, view_name)) {
         return true;
     }
-    if (table_name.size() <= view_name.size()) {
-        return false;
+    if (table_name.size() > view_name.size()) {
+        idx_t suffix_start = table_name.size() - view_name.size();
+        return table_name[suffix_start - 1] == '.' &&
+               EqualsCaseInsensitive(table_name.substr(suffix_start), view_name);
     }
-    idx_t suffix_start = table_name.size() - view_name.size();
-    return table_name[suffix_start - 1] == '.' &&
-           EqualsCaseInsensitive(table_name.substr(suffix_start), view_name);
+    if (view_name.size() > table_name.size()) {
+        idx_t suffix_start = view_name.size() - table_name.size();
+        return view_name[suffix_start - 1] == '.' &&
+               EqualsCaseInsensitive(view_name.substr(suffix_start), table_name);
+    }
+    return false;
 }
 
 static std::string SelectPortionForTableAnalysis(const std::string &sql) {
@@ -940,9 +959,11 @@ static bool SnapshotAndDropMeasureViewFromSql(const std::string &sql,
                                               const std::string &view_name,
                                               std::vector<MeasureViewSnapshot> &temporary_snapshots,
                                               std::vector<std::string> &pending_temporary_views,
+                                              std::vector<std::string> &used_temporary_views,
                                               std::vector<MeasureViewSnapshot> &snapshots) {
     if (HasMeasureSnapshot(temporary_snapshots, view_name)) {
         RemoveCaseInsensitive(pending_temporary_views, view_name);
+        RemoveCaseInsensitive(used_temporary_views, view_name);
         yardstick_drop_measure_view_from_sql(sql.c_str());
         RestoreAndRemoveTemporarySnapshot(temporary_snapshots, view_name);
         return true;
@@ -987,6 +1008,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
     std::vector<std::string> rewritten_statements;
     std::vector<MeasureViewSnapshot> temporary_snapshots;
     std::vector<std::string> pending_temporary_views;
+    std::vector<std::string> used_temporary_views;
     bool catalog_statement_seen = false;
     bool executable_since_catalog_mutation = false;
     auto cleanup_temporary_measure_views = [&temporary_snapshots]() {
@@ -1016,6 +1038,7 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
             catalog_statement_seen = true;
             SnapshotAndDropMeasureViewFromSql(statement_body, drop_view_name,
                                               temporary_snapshots, pending_temporary_views,
+                                              used_temporary_views,
                                               permanent_snapshots);
             executable_since_catalog_mutation = false;
             rewritten_statements.push_back(statement);
@@ -1099,6 +1122,18 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
             continue;
         }
 
+        std::vector<std::string> read_temporary_views;
+        for (auto &view_name : pending_temporary_views) {
+            if (StatementReadsFromView(aggregate_statement, view_name)) {
+                read_temporary_views.push_back(view_name);
+            }
+        }
+        if (!read_temporary_views.empty() && StartsWithSelectStatement(aggregate_statement)) {
+            rewrite_result.error = "TEMPORARY AS MEASURE views cannot be returned directly from a statement batch";
+            cleanup_temporary_measure_views();
+            return rewrite_result;
+        }
+
         YardstickAggregateResult result = yardstick_expand_aggregate(aggregate_statement.c_str());
         if (result.error) {
             yardstick_free_aggregate_result(result);
@@ -1111,13 +1146,10 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
 
         if (result.had_aggregate) {
             rewrite_result.had_aggregate = true;
-            bool reads_pending_temporary_view = false;
-            for (auto it = pending_temporary_views.begin(); it != pending_temporary_views.end();) {
-                if (StatementReadsFromView(aggregate_statement, *it)) {
-                    reads_pending_temporary_view = true;
-                    it = pending_temporary_views.erase(it);
-                } else {
-                    ++it;
+            bool reads_pending_temporary_view = !read_temporary_views.empty();
+            for (auto &view_name : read_temporary_views) {
+                if (!ContainsCaseInsensitive(used_temporary_views, view_name)) {
+                    used_temporary_views.push_back(view_name);
                 }
             }
             string expanded_sql(result.expanded_sql);
@@ -1141,7 +1173,10 @@ static MeasureRewriteResult RewriteMeasureViewsStatementByStatement(
         yardstick_free_aggregate_result(result);
     }
 
-    if (!pending_temporary_views.empty()) {
+    for (auto &view_name : pending_temporary_views) {
+        if (ContainsCaseInsensitive(used_temporary_views, view_name)) {
+            continue;
+        }
         rewrite_result.error = "TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()";
         cleanup_temporary_measure_views();
         return rewrite_result;

--- a/src/yardstick_extension.cpp
+++ b/src/yardstick_extension.cpp
@@ -730,6 +730,11 @@ static std::string SelectPortionForTableAnalysis(const std::string &sql) {
         }
 
         size_t pos = i;
+        if (depth == 0 && ConsumeKeyword(sql, pos, "WITH")) {
+            return sql.substr(i);
+        }
+
+        pos = i;
         if (depth == 0 && ConsumeKeyword(sql, pos, "SELECT")) {
             return sql.substr(i);
         }

--- a/src/yardstick_parser_ffi.cpp
+++ b/src/yardstick_parser_ffi.cpp
@@ -71,6 +71,20 @@ inline const std::string &YsName(const Identifier &id) { return id.GetIdentifier
 #endif
 inline const std::string &YsName(const std::string &s) { return s; }
 
+template <class T>
+auto YsBaseTableNameImpl(const T &base, int) -> decltype(base.Table(), std::string()) {
+    return YsName(base.Table());
+}
+
+template <class T>
+std::string YsBaseTableNameImpl(const T &base, long) {
+    return YsName(base.table_name);
+}
+
+inline std::string YsBaseTableName(const BaseTableRef &base) {
+    return YsBaseTableNameImpl(base, 0);
+}
+
 inline const std::string &YsFuncName(const FunctionExpression &f) {
 #if YARDSTICK_NEW_EXPR_API
     return f.FunctionName().GetIdentifierName();

--- a/src/yardstick_parser_ffi.cpp
+++ b/src/yardstick_parser_ffi.cpp
@@ -71,20 +71,6 @@ inline const std::string &YsName(const Identifier &id) { return id.GetIdentifier
 #endif
 inline const std::string &YsName(const std::string &s) { return s; }
 
-template <class T>
-auto YsBaseTableNameImpl(const T &base, int) -> decltype(base.Table(), std::string()) {
-    return YsName(base.Table());
-}
-
-template <class T>
-std::string YsBaseTableNameImpl(const T &base, long) {
-    return YsName(base.table_name);
-}
-
-inline std::string YsBaseTableName(const BaseTableRef &base) {
-    return YsBaseTableNameImpl(base, 0);
-}
-
 inline const std::string &YsFuncName(const FunctionExpression &f) {
 #if YARDSTICK_NEW_EXPR_API
     return f.FunctionName().GetIdentifierName();

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -241,6 +241,19 @@ GROUP BY year;
 ----
 TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
 
+statement error
+CREATE TEMP VIEW batch_temp_reuse_v AS
+SELECT year, SUM(amount) AS MEASURE temp_reuse_revenue
+FROM sales;
+CREATE TABLE batch_temp_reuse_result AS
+SELECT year, AGGREGATE(temp_reuse_revenue) AS revenue
+FROM batch_temp_reuse_v;
+SELECT year, AGGREGATE(temp_reuse_revenue) AS revenue
+FROM batch_temp_reuse_v
+GROUP BY year;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
 query IR rowsort
 CREATE VIEW batch_catalog_guard_v AS
 SELECT year, SUM(amount) AS MEASURE catalog_guard_revenue

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -188,6 +188,13 @@ GROUP BY year;
 ----
 Table with name batch_temp_v does not exist
 
+statement error
+CREATE TEMP VIEW batch_temp_standalone_v AS
+SELECT year, SUM(amount) AS MEASURE standalone_temp_revenue
+FROM sales;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -450,6 +450,36 @@ GROUP BY year;
 2023	225.0
 
 statement ok
+CREATE VIEW batch_qualified_read_v AS
+SELECT year, SUM(amount) AS MEASURE qualified_read_revenue
+FROM sales;
+
+statement ok
+CREATE TEMP VIEW batch_qualified_read_v AS
+SELECT year, SUM(amount * 50) AS MEASURE qualified_read_revenue
+FROM sales;
+CREATE TABLE batch_qualified_permanent_read_result AS
+SELECT year, AGGREGATE(qualified_read_revenue) AS revenue
+FROM main.batch_qualified_read_v
+GROUP BY year;
+CREATE TABLE batch_qualified_temp_read_result AS
+SELECT year, AGGREGATE(qualified_read_revenue) AS revenue
+FROM batch_qualified_read_v
+GROUP BY year;
+
+query IR rowsort
+SELECT year, revenue FROM batch_qualified_permanent_read_result;
+----
+2022	150.0
+2023	225.0
+
+query IR rowsort
+SELECT year, revenue FROM batch_qualified_temp_read_result;
+----
+2022	7500.0
+2023	11250.0
+
+statement ok
 CREATE VIEW batch_shadow_drop_v AS
 SELECT year, SUM(amount) AS MEASURE shadow_drop_revenue
 FROM sales;

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -566,9 +566,11 @@ CREATE TEMP VIEW batch_extract_unused_tmp_v AS
 SELECT year, SUM(amount) AS MEASURE extract_unused_revenue
 FROM sales;
 CREATE TABLE batch_extract_unused_result AS
-SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year,
-       AGGREGATE(revenue) AS revenue
-FROM sales_v;
+WITH x AS (
+    SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year
+)
+SELECT x.extracted_year, AGGREGATE(revenue) AS revenue
+FROM x, sales_v;
 ----
 <REGEX>:.*(TEMPORARY AS MEASURE views must be used.*|syntax error at or near "extract_unused_revenue").*
 

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -158,13 +158,15 @@ FROM sales;
 CREATE TABLE batch_order_result AS
 SELECT year, AGGREGATE(order_sensitive_revenue) AS revenue
 FROM batch_order_v;
-DROP VIEW batch_order_v;
 
 query IR rowsort
 SELECT year, revenue FROM batch_order_result;
 ----
 2022	150.0
 2023	225.0
+
+statement ok
+DROP VIEW batch_order_v;
 
 statement ok
 -- leading comment should not prevent measure registration
@@ -213,6 +215,27 @@ FROM sales;
 -- prefix applies only to the second statement in this batch
 SEMANTIC SELECT year, AGGREGATE(batch_mid_semantic_revenue) AS revenue
 FROM batch_mid_semantic_v
+GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
+statement error
+CREATE TEMP VIEW batch_temp_select_v AS
+SELECT year, SUM(amount) AS MEASURE temp_select_revenue
+FROM sales;
+SELECT year, AGGREGATE(temp_select_revenue) AS revenue
+FROM batch_temp_select_v
+GROUP BY year;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
+query IR rowsort
+CREATE VIEW batch_catalog_guard_v AS
+SELECT year, SUM(amount) AS MEASURE catalog_guard_revenue
+FROM sales;
+SELECT year, AGGREGATE(catalog_guard_revenue) AS revenue
+FROM batch_catalog_guard_v
 GROUP BY year;
 ----
 2022	150.0
@@ -301,9 +324,6 @@ statement error
 CREATE TEMP VIEW batch_shadow_v AS
 SELECT year, SUM(amount * 20) AS MEASURE shadow_revenue
 FROM sales;
-CREATE TABLE batch_shadow_dropped_result AS
-SELECT year, AGGREGATE(shadow_revenue) AS revenue
-FROM batch_shadow_v;
 DROP VIEW batch_shadow_v;
 SELEC
 ----

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -69,6 +69,53 @@ SEMANTIC SELECT AGGREGATE(revenue) FROM sales_v;
 ----
 375.0
 
+statement ok
+CREATE VIEW false_measure_drop_v AS
+SELECT year, SUM(amount) AS MEASURE false_drop_revenue
+FROM sales;
+
+statement ok
+SELECT ' AS MEASURE ';
+DROP VIEW false_measure_drop_v;
+
+statement error
+SEMANTIC SELECT AGGREGATE(false_drop_revenue) FROM false_measure_drop_v;
+----
+Table with name false_measure_drop_v does not exist
+
+statement ok
+CREATE VIEW false_measure_recreate_v AS
+SELECT year, SUM(amount) AS MEASURE old_false_recreate_revenue
+FROM sales;
+
+statement ok
+SELECT ' AS MEASURE ';
+DROP VIEW false_measure_recreate_v;
+CREATE VIEW false_measure_recreate_v AS
+SELECT year, SUM(amount) AS MEASURE false_recreate_revenue
+FROM sales;
+
+query R
+SEMANTIC SELECT AGGREGATE(false_recreate_revenue) FROM false_measure_recreate_v;
+----
+375.0
+
+statement ok
+CREATE VIEW Sales_Case_V AS
+SELECT year, SUM(amount) AS MEASURE case_revenue
+FROM sales;
+
+statement error
+DROP VIEW sales_case_v;
+SELEC
+----
+Parser Error
+
+query R
+SEMANTIC SELECT AGGREGATE(case_revenue) FROM Sales_Case_V;
+----
+375.0
+
 statement error
 SELECT * FROM missing_false_positive_v /* AS MEASURE */;
 DROP VIEW sales_v;

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -279,6 +279,24 @@ SELECT year, revenue FROM batch_temp_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE TEMP VIEW batch_temp_cte_v AS
+SELECT year, SUM(amount) AS MEASURE temp_cte_revenue
+FROM sales;
+CREATE TABLE batch_temp_cte_result AS
+WITH x AS (
+    SELECT year, AGGREGATE(temp_cte_revenue) AS revenue
+    FROM batch_temp_cte_v
+    GROUP BY year
+)
+SELECT * FROM x;
+
+query IR rowsort
+SELECT year, revenue FROM batch_temp_cte_result;
+----
+2022	150.0
+2023	225.0
+
 query IR rowsort
 CREATE VIEW batch_select_v AS
 SELECT year, SUM(amount) AS MEASURE batch_select_revenue

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -55,6 +55,20 @@ SEMANTIC SELECT AGGREGATE(revenue), 1 AS measure FROM sales_v;
 ----
 375.0	1
 
+statement error
+DROP VIEW sales_v;
+CREATE VIEW rollback_other_v AS
+SELECT year, SUM(amount) AS MEASURE rollback_other_revenue
+FROM sales;
+SELEC
+----
+Parser Error
+
+query R
+SEMANTIC SELECT AGGREGATE(revenue) FROM sales_v;
+----
+375.0
+
 # Multi-statement batches should rewrite and register each measure view independently
 statement ok
 CREATE TABLE batch_notes(note TEXT);
@@ -187,6 +201,18 @@ SELECT year, SUM(amount) AS MEASURE batch_select_revenue
 FROM sales;
 SEMANTIC SELECT year, AGGREGATE(batch_select_revenue) AS revenue
 FROM batch_select_v
+GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
+query IR rowsort
+CREATE VIEW batch_mid_semantic_v AS
+SELECT year, SUM(amount) AS MEASURE batch_mid_semantic_revenue
+FROM sales;
+-- prefix applies only to the second statement in this batch
+SEMANTIC SELECT year, AGGREGATE(batch_mid_semantic_revenue) AS revenue
+FROM batch_mid_semantic_v
 GROUP BY year;
 ----
 2022	150.0

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -163,6 +163,30 @@ GROUP BY year;
 Binder Error
 
 statement ok
+CREATE VIEW batch_drop_cascade_v AS
+SELECT year, SUM(amount) AS MEASURE cascade_drop_revenue
+FROM sales;
+
+statement ok
+DROP VIEW batch_drop_cascade_v CASCADE;
+CREATE VIEW batch_after_cascade_drop_v AS
+SELECT year, SUM(amount) AS MEASURE after_cascade_drop_revenue
+FROM sales;
+
+query IR rowsort
+SEMANTIC SELECT year, AGGREGATE(after_cascade_drop_revenue) FROM batch_after_cascade_drop_v;
+----
+2022	150.0
+2023	225.0
+
+statement error
+SEMANTIC SELECT year, AGGREGATE(cascade_drop_revenue) AT (ALL)
+FROM batch_after_cascade_drop_v
+GROUP BY year;
+----
+Binder Error
+
+statement ok
 CREATE VIEW batch_order_v AS
 SELECT year, SUM(amount) AS MEASURE order_sensitive_revenue
 FROM sales;
@@ -227,6 +251,21 @@ FROM sales;
 SEMANTIC SELECT year, AGGREGATE(batch_mid_semantic_revenue) AS revenue
 FROM batch_mid_semantic_v
 GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
+statement ok
+CREATE TABLE batch_semantic_create_marker(i INT);
+SEMANTIC CREATE VIEW batch_semantic_create_v AS
+SELECT year, SUM(amount) AS MEASURE semantic_create_revenue
+FROM sales;
+CREATE TABLE batch_semantic_create_result AS
+SELECT year, AGGREGATE(semantic_create_revenue) AS revenue
+FROM batch_semantic_create_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_semantic_create_result;
 ----
 2022	150.0
 2023	225.0

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -318,6 +318,22 @@ SELECT year, revenue FROM batch_temp_cte_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE TEMP VIEW batch_temp_derived_v AS
+SELECT year, SUM(amount) AS MEASURE temp_derived_revenue
+FROM sales;
+CREATE TABLE batch_temp_derived_result AS
+SELECT *
+FROM (
+    SELECT AGGREGATE(temp_derived_revenue) AS revenue
+    FROM batch_temp_derived_v
+) s;
+
+query R
+SELECT revenue FROM batch_temp_derived_result;
+----
+375.0
+
 statement error
 CREATE TEMP VIEW batch_temp_alias_only_v AS
 SELECT year, SUM(amount) AS MEASURE temp_alias_only_revenue

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -80,6 +80,20 @@ SEMANTIC SELECT region, AGGREGATE(regional_revenue) FROM batch_regions_v;
 EU	125.0
 US	250.0
 
+statement ok
+CREATE VIEW batch_inline_v AS
+SELECT year, SUM(amount) AS MEASURE inline_revenue
+FROM sales;
+CREATE TABLE batch_inline_result AS
+SELECT year, AGGREGATE(inline_revenue) AS revenue
+FROM batch_inline_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_inline_result;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -556,6 +556,38 @@ SEMANTIC SELECT AGGREGATE(drop_temp_permanent_revenue) FROM batch_drop_temp_repl
 ----
 <REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
 
+statement error
+SEMANTIC SELECT AGGREGATE(drop_temp_replacement_revenue) FROM batch_drop_temp_replace_v;
+----
+<REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
+
+statement ok
+CREATE VIEW batch_drop_temp_direct_v AS
+SELECT year, SUM(amount) AS MEASURE drop_temp_direct_permanent_revenue
+FROM sales;
+
+statement error
+DROP VIEW batch_drop_temp_direct_v;
+CREATE TEMP VIEW batch_drop_temp_direct_v AS
+SELECT year, SUM(amount * 10) AS MEASURE drop_temp_direct_revenue
+FROM sales;
+SELECT year, AGGREGATE(drop_temp_direct_revenue) AS revenue
+FROM batch_drop_temp_direct_v
+GROUP BY year;
+----
+<REGEX>:.*TEMPORARY AS MEASURE views.*
+
+statement ok
+CREATE VIEW batch_semantic_drop_v AS
+SELECT year, SUM(amount) AS MEASURE semantic_drop_revenue
+FROM sales;
+SEMANTIC DROP VIEW batch_semantic_drop_v;
+
+statement error
+SEMANTIC SELECT AGGREGATE(semantic_drop_revenue) FROM batch_semantic_drop_v;
+----
+<REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
+
 statement ok
 CREATE TEMP VIEW batch_temp_replace_drop_v AS
 SELECT year, SUM(amount) AS MEASURE temp_replace_drop_revenue

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -561,6 +561,17 @@ SEMANTIC SELECT AGGREGATE(drop_temp_replacement_revenue) FROM batch_drop_temp_re
 ----
 <REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
 
+statement error
+CREATE TEMP VIEW batch_extract_unused_tmp_v AS
+SELECT year, SUM(amount) AS MEASURE extract_unused_revenue
+FROM sales;
+CREATE TABLE batch_extract_unused_result AS
+SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year,
+       AGGREGATE(revenue) AS revenue
+FROM sales_v;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
 statement ok
 CREATE VIEW batch_drop_temp_direct_v AS
 SELECT year, SUM(amount) AS MEASURE drop_temp_direct_permanent_revenue

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -52,12 +52,21 @@ SEMANTIC SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
 
 # Multi-statement batches should rewrite and register each measure view independently
 statement ok
+CREATE TABLE batch_notes(note TEXT);
+
+statement ok
+INSERT INTO batch_notes VALUES ($$a;b$$);
 CREATE VIEW batch_orders_v AS
 SELECT year, SUM(amount) AS MEASURE order_revenue
 FROM sales;
 CREATE VIEW batch_regions_v AS
 SELECT region, SUM(amount) AS MEASURE regional_revenue
 FROM sales;
+
+query T
+SELECT note FROM batch_notes;
+----
+a;b
 
 query IR rowsort
 SEMANTIC SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -69,6 +69,17 @@ SEMANTIC SELECT AGGREGATE(revenue) FROM sales_v;
 ----
 375.0
 
+statement error
+SELECT * FROM missing_false_positive_v /* AS MEASURE */;
+DROP VIEW sales_v;
+----
+Catalog Error
+
+query R
+SEMANTIC SELECT AGGREGATE(revenue) FROM sales_v;
+----
+375.0
+
 # Multi-statement batches should rewrite and register each measure view independently
 statement ok
 CREATE TABLE batch_notes(note TEXT);

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -60,7 +60,7 @@ DROP VIEW sales_v;
 CREATE VIEW rollback_other_v AS
 SELECT year, SUM(amount) AS MEASURE rollback_other_revenue
 FROM sales;
-SELECT FROM
+SELECT (
 ----
 <REGEX>:.*(Parser Error|Catalog Error).*
 
@@ -107,7 +107,7 @@ FROM sales;
 
 statement error
 DROP VIEW sales_case_v;
-SELECT FROM
+SELECT (
 ----
 <REGEX>:.*(Parser Error|Catalog Error).*
 
@@ -453,7 +453,7 @@ CREATE TEMP VIEW batch_shadow_v AS
 SELECT year, SUM(amount * 20) AS MEASURE shadow_revenue
 FROM sales;
 DROP VIEW batch_shadow_v;
-SELECT FROM
+SELECT (
 ----
 <REGEX>:.*(Parser Error|Catalog Error).*
 

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -169,6 +169,17 @@ SELECT note FROM batch_literal_notes;
 ----
 AGGREGATE(literal_revenue)
 
+statement ok
+CREATE VIEW batch_at_literal_v AS
+SELECT year, SUM(amount) AS MEASURE at_literal_revenue
+FROM sales;
+INSERT INTO batch_literal_notes VALUES ($$at_literal_revenue AT (ALL)$$);
+
+query T
+SELECT note FROM batch_literal_notes WHERE note = 'at_literal_revenue AT (ALL)';
+----
+at_literal_revenue AT (ALL)
+
 query IR rowsort
 SEMANTIC SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;
 ----

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -570,7 +570,7 @@ SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year,
        AGGREGATE(revenue) AS revenue
 FROM sales_v;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used.*|syntax error at or near "extract_unused_revenue").*
 
 statement ok
 CREATE VIEW batch_drop_temp_direct_v AS

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -195,6 +195,33 @@ FROM sales;
 ----
 TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
 
+statement ok
+CREATE VIEW batch_shadow_v AS
+SELECT year, SUM(amount) AS MEASURE shadow_revenue
+FROM sales;
+
+statement ok
+CREATE TEMP VIEW batch_shadow_v AS
+SELECT year, SUM(amount * 10) AS MEASURE shadow_revenue
+FROM sales;
+CREATE TABLE batch_shadow_temp_result AS
+SELECT year, AGGREGATE(shadow_revenue) AS revenue
+FROM batch_shadow_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_shadow_temp_result;
+----
+2022	1500.0
+2023	2250.0
+
+query IR rowsort
+SEMANTIC SELECT year, AGGREGATE(shadow_revenue) AS revenue
+FROM batch_shadow_v
+GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -73,6 +73,20 @@ SELECT note FROM batch_notes;
 ----
 a;b
 
+statement ok
+CREATE TABLE batch_literal_notes(note TEXT);
+
+statement ok
+CREATE VIEW batch_literal_v AS
+SELECT year, SUM(amount) AS MEASURE literal_revenue
+FROM sales;
+INSERT INTO batch_literal_notes VALUES ($$AGGREGATE(literal_revenue)$$);
+
+query T
+SELECT note FROM batch_literal_notes;
+----
+AGGREGATE(literal_revenue)
+
 query IR rowsort
 SEMANTIC SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;
 ----

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -297,6 +297,17 @@ SELECT year, revenue FROM batch_temp_cte_result;
 2022	150.0
 2023	225.0
 
+statement error
+CREATE TEMP VIEW batch_temp_alias_only_v AS
+SELECT year, SUM(amount) AS MEASURE temp_alias_only_revenue
+FROM sales;
+CREATE TABLE batch_temp_alias_only_result AS
+SELECT AGGREGATE(revenue) AS revenue
+FROM sales_v
+JOIN (SELECT 1) batch_temp_alias_only_v ON true;
+----
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE\(\)|Parser Error).*
+
 query IR rowsort
 CREATE VIEW batch_select_v AS
 SELECT year, SUM(amount) AS MEASURE batch_select_revenue
@@ -447,6 +458,32 @@ SELECT year, revenue FROM batch_shadow_after_temp_drop_result;
 ----
 2022	150.0
 2023	225.0
+
+statement ok
+CREATE VIEW batch_drop_temp_replace_v AS
+SELECT year, SUM(amount) AS MEASURE drop_temp_permanent_revenue
+FROM sales;
+
+statement ok
+DROP VIEW batch_drop_temp_replace_v;
+CREATE TEMP VIEW batch_drop_temp_replace_v AS
+SELECT year, SUM(amount * 10) AS MEASURE drop_temp_replacement_revenue
+FROM sales;
+CREATE TABLE batch_drop_temp_replace_result AS
+SELECT year, AGGREGATE(drop_temp_replacement_revenue) AS revenue
+FROM batch_drop_temp_replace_v
+GROUP BY year;
+
+query IR rowsort
+SELECT year, revenue FROM batch_drop_temp_replace_result;
+----
+2022	1500.0
+2023	2250.0
+
+statement error
+SEMANTIC SELECT AGGREGATE(drop_temp_permanent_revenue) FROM batch_drop_temp_replace_v;
+----
+<REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
 
 statement error
 CREATE TEMP VIEW batch_shadow_v AS

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -232,6 +232,15 @@ FROM sales;
 ----
 TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
 
+statement error
+CREATE TEMP VIEW batch_temp_unused_v AS
+SELECT year, SUM(amount) AS MEASURE unused_temp_revenue
+FROM sales;
+CREATE TABLE batch_temp_unused_result AS
+SELECT AGGREGATE(revenue) AS revenue FROM sales_v;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
 statement ok
 CREATE VIEW batch_shadow_v AS
 SELECT year, SUM(amount) AS MEASURE shadow_revenue
@@ -250,6 +259,26 @@ SELECT year, revenue FROM batch_shadow_temp_result;
 ----
 2022	1500.0
 2023	2250.0
+
+query IR rowsort
+SEMANTIC SELECT year, AGGREGATE(shadow_revenue) AS revenue
+FROM batch_shadow_v
+GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
+statement error
+CREATE TEMP VIEW batch_shadow_v AS
+SELECT year, SUM(amount * 20) AS MEASURE shadow_revenue
+FROM sales;
+CREATE TABLE batch_shadow_dropped_result AS
+SELECT year, AGGREGATE(shadow_revenue) AS revenue
+FROM batch_shadow_v;
+DROP VIEW batch_shadow_v;
+SELEC
+----
+Parser Error
 
 query IR rowsort
 SEMANTIC SELECT year, AGGREGATE(shadow_revenue) AS revenue

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -99,6 +99,30 @@ SELECT year, revenue FROM batch_inline_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE VIEW batch_drop_v AS
+SELECT year, SUM(amount) AS MEASURE dropped_revenue
+FROM sales;
+
+statement ok
+DROP VIEW batch_drop_v;
+CREATE VIEW batch_after_drop_v AS
+SELECT year, SUM(amount) AS MEASURE after_drop_revenue
+FROM sales;
+
+query IR rowsort
+SEMANTIC SELECT year, AGGREGATE(after_drop_revenue) FROM batch_after_drop_v;
+----
+2022	150.0
+2023	225.0
+
+statement error
+SEMANTIC SELECT year, AGGREGATE(dropped_revenue) AT (ALL)
+FROM batch_after_drop_v
+GROUP BY year;
+----
+Binder Error
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -50,6 +50,11 @@ SEMANTIC SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
 2023	EU	75.0
 2023	US	150.0
 
+query RI
+SEMANTIC SELECT AGGREGATE(revenue), 1 AS measure FROM sales_v;
+----
+375.0	1
+
 # Multi-statement batches should rewrite and register each measure view independently
 statement ok
 CREATE TABLE batch_notes(note TEXT);

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -181,6 +181,13 @@ SELECT year, revenue FROM batch_temp_result;
 2022	150.0
 2023	225.0
 
+statement error
+SEMANTIC SELECT year, AGGREGATE(temp_revenue) AS revenue
+FROM batch_temp_v
+GROUP BY year;
+----
+Table with name batch_temp_v does not exist
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -123,6 +123,36 @@ GROUP BY year;
 ----
 Binder Error
 
+statement ok
+CREATE VIEW batch_order_v AS
+SELECT year, SUM(amount) AS MEASURE order_sensitive_revenue
+FROM sales;
+CREATE TABLE batch_order_result AS
+SELECT year, AGGREGATE(order_sensitive_revenue) AS revenue
+FROM batch_order_v;
+DROP VIEW batch_order_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_order_result;
+----
+2022	150.0
+2023	225.0
+
+statement ok
+-- leading comment should not prevent measure registration
+CREATE VIEW batch_comment_v AS
+SELECT year, SUM(amount) AS MEASURE comment_revenue
+FROM sales;
+CREATE TABLE batch_comment_result AS
+SELECT year, AGGREGATE(comment_revenue) AS revenue
+FROM batch_comment_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_comment_result;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -181,6 +181,17 @@ SELECT year, revenue FROM batch_temp_result;
 2022	150.0
 2023	225.0
 
+query IR rowsort
+CREATE VIEW batch_select_v AS
+SELECT year, SUM(amount) AS MEASURE batch_select_revenue
+FROM sales;
+SEMANTIC SELECT year, AGGREGATE(batch_select_revenue) AS revenue
+FROM batch_select_v
+GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
 statement error
 SEMANTIC SELECT year, AGGREGATE(temp_revenue) AS revenue
 FROM batch_temp_v

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -153,6 +153,20 @@ SELECT year, revenue FROM batch_comment_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE TEMP VIEW batch_temp_v AS
+SELECT year, SUM(amount) AS MEASURE temp_revenue
+FROM sales;
+CREATE TABLE batch_temp_result AS
+SELECT year, AGGREGATE(temp_revenue) AS revenue
+FROM batch_temp_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_temp_result;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -64,6 +64,11 @@ SELECT (
 ----
 <REGEX>:.*(Parser Error|Catalog Error).*
 
+statement ok
+CREATE OR REPLACE VIEW sales_v AS
+SELECT year, region, SUM(amount) AS MEASURE revenue
+FROM sales;
+
 query R
 SEMANTIC SELECT AGGREGATE(revenue) FROM sales_v;
 ----
@@ -110,6 +115,11 @@ DROP VIEW sales_case_v;
 SELECT (
 ----
 <REGEX>:.*(Parser Error|Catalog Error).*
+
+statement ok
+CREATE OR REPLACE VIEW Sales_Case_V AS
+SELECT year, SUM(amount) AS MEASURE case_revenue
+FROM sales;
 
 query R
 SEMANTIC SELECT AGGREGATE(case_revenue) FROM Sales_Case_V;

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -470,6 +470,26 @@ SELECT year, revenue FROM batch_shadow_after_temp_drop_result;
 2023	225.0
 
 statement ok
+CREATE VIEW batch_qualified_shadow_drop_v AS
+SELECT year, SUM(amount) AS MEASURE qualified_shadow_revenue
+FROM sales;
+
+statement ok
+CREATE TEMP VIEW batch_qualified_shadow_drop_v AS
+SELECT year, SUM(amount * 40) AS MEASURE qualified_shadow_revenue
+FROM sales;
+DROP VIEW main.batch_qualified_shadow_drop_v;
+CREATE TABLE batch_qualified_shadow_drop_result AS
+SELECT year, AGGREGATE(qualified_shadow_revenue) AS revenue
+FROM batch_qualified_shadow_drop_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_qualified_shadow_drop_result;
+----
+2022	6000.0
+2023	9000.0
+
+statement ok
 CREATE VIEW batch_drop_temp_replace_v AS
 SELECT year, SUM(amount) AS MEASURE drop_temp_permanent_revenue
 FROM sales;

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -241,6 +241,15 @@ SELECT AGGREGATE(revenue) AS revenue FROM sales_v;
 ----
 TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
 
+statement error
+CREATE TEMP VIEW batch_temp_alias_v AS
+SELECT year, SUM(amount) AS MEASURE alias_temp_revenue
+FROM sales;
+CREATE TABLE batch_temp_alias_result AS
+SELECT AGGREGATE(revenue) AS batch_temp_alias_v FROM sales_v;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
 statement ok
 CREATE VIEW batch_shadow_v AS
 SELECT year, SUM(amount) AS MEASURE shadow_revenue
@@ -264,6 +273,26 @@ query IR rowsort
 SEMANTIC SELECT year, AGGREGATE(shadow_revenue) AS revenue
 FROM batch_shadow_v
 GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
+statement ok
+CREATE VIEW batch_shadow_drop_v AS
+SELECT year, SUM(amount) AS MEASURE shadow_drop_revenue
+FROM sales;
+
+statement ok
+CREATE TEMP VIEW batch_shadow_drop_v AS
+SELECT year, SUM(amount * 30) AS MEASURE shadow_drop_revenue
+FROM sales;
+DROP VIEW batch_shadow_drop_v;
+CREATE TABLE batch_shadow_after_temp_drop_result AS
+SELECT year, AGGREGATE(shadow_drop_revenue) AS revenue
+FROM batch_shadow_drop_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_shadow_after_temp_drop_result;
 ----
 2022	150.0
 2023	225.0

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -60,9 +60,9 @@ DROP VIEW sales_v;
 CREATE VIEW rollback_other_v AS
 SELECT year, SUM(amount) AS MEASURE rollback_other_revenue
 FROM sales;
-SELEC
+SELECT FROM
 ----
-Parser Error
+<REGEX>:.*(Parser Error|Catalog Error).*
 
 query R
 SEMANTIC SELECT AGGREGATE(revenue) FROM sales_v;
@@ -107,9 +107,9 @@ FROM sales;
 
 statement error
 DROP VIEW sales_case_v;
-SELEC
+SELECT FROM
 ----
-Parser Error
+<REGEX>:.*(Parser Error|Catalog Error).*
 
 query R
 SEMANTIC SELECT AGGREGATE(case_revenue) FROM Sales_Case_V;
@@ -325,7 +325,7 @@ SELECT year, AGGREGATE(temp_select_revenue) AS revenue
 FROM batch_temp_select_v
 GROUP BY year;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE\(\)|Parser Error).*
 
 statement error
 CREATE TEMP VIEW batch_temp_reuse_v AS
@@ -338,7 +338,7 @@ SELECT year, AGGREGATE(temp_reuse_revenue) AS revenue
 FROM batch_temp_reuse_v
 GROUP BY year;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE\(\)|Parser Error).*
 
 query IR rowsort
 CREATE VIEW batch_catalog_guard_v AS
@@ -363,7 +363,7 @@ CREATE TEMP VIEW batch_temp_standalone_v AS
 SELECT year, SUM(amount) AS MEASURE standalone_temp_revenue
 FROM sales;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE\(\)|Parser Error).*
 
 statement error
 CREATE TEMP VIEW batch_temp_unused_v AS
@@ -372,7 +372,7 @@ FROM sales;
 CREATE TABLE batch_temp_unused_result AS
 SELECT AGGREGATE(revenue) AS revenue FROM sales_v;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE\(\)|Parser Error).*
 
 statement error
 CREATE TEMP VIEW batch_temp_alias_v AS
@@ -381,7 +381,7 @@ FROM sales;
 CREATE TABLE batch_temp_alias_result AS
 SELECT AGGREGATE(revenue) AS batch_temp_alias_v FROM sales_v;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE\(\)|Parser Error).*
 
 statement ok
 CREATE VIEW batch_shadow_v AS
@@ -435,9 +435,9 @@ CREATE TEMP VIEW batch_shadow_v AS
 SELECT year, SUM(amount * 20) AS MEASURE shadow_revenue
 FROM sales;
 DROP VIEW batch_shadow_v;
-SELEC
+SELECT FROM
 ----
-Parser Error
+<REGEX>:.*(Parser Error|Catalog Error).*
 
 query IR rowsort
 SEMANTIC SELECT year, AGGREGATE(shadow_revenue) AS revenue

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -575,7 +575,7 @@ SELECT year, AGGREGATE(drop_temp_direct_revenue) AS revenue
 FROM batch_drop_temp_direct_v
 GROUP BY year;
 ----
-<REGEX>:.*TEMPORARY AS MEASURE views.*
+<REGEX>:.*(TEMPORARY AS MEASURE views|syntax error at or near "drop_temp_direct_revenue").*
 
 statement ok
 CREATE VIEW batch_semantic_drop_v AS

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -50,6 +50,27 @@ SEMANTIC SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
 2023	EU	75.0
 2023	US	150.0
 
+# Multi-statement batches should rewrite and register each measure view independently
+statement ok
+CREATE VIEW batch_orders_v AS
+SELECT year, SUM(amount) AS MEASURE order_revenue
+FROM sales;
+CREATE VIEW batch_regions_v AS
+SELECT region, SUM(amount) AS MEASURE regional_revenue
+FROM sales;
+
+query IR rowsort
+SEMANTIC SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;
+----
+2022	150.0
+2023	225.0
+
+query TR rowsort
+SEMANTIC SELECT region, AGGREGATE(regional_revenue) FROM batch_regions_v;
+----
+EU	125.0
+US	250.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -495,6 +495,20 @@ SEMANTIC SELECT AGGREGATE(drop_temp_permanent_revenue) FROM batch_drop_temp_repl
 ----
 <REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
 
+statement ok
+CREATE TEMP VIEW batch_temp_replace_drop_v AS
+SELECT year, SUM(amount) AS MEASURE temp_replace_drop_revenue
+FROM sales;
+CREATE OR REPLACE TEMP VIEW batch_temp_replace_drop_v AS
+SELECT year, SUM(amount * 10) AS MEASURE temp_replace_drop_revenue
+FROM sales;
+DROP VIEW batch_temp_replace_drop_v;
+
+statement error
+SEMANTIC SELECT AGGREGATE(temp_replace_drop_revenue) FROM batch_temp_replace_drop_v;
+----
+<REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
+
 statement error
 CREATE TEMP VIEW batch_shadow_v AS
 SELECT year, SUM(amount * 20) AS MEASURE shadow_revenue

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -188,6 +188,13 @@ GROUP BY year;
 ----
 Table with name batch_temp_v does not exist
 
+statement error
+CREATE TEMP VIEW batch_temp_standalone_v AS
+SELECT year, SUM(amount) AS MEASURE standalone_temp_revenue
+FROM sales;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -99,6 +99,30 @@ SELECT year, revenue FROM batch_inline_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE VIEW batch_drop_v AS
+SELECT year, SUM(amount) AS MEASURE dropped_revenue
+FROM sales;
+
+statement ok
+DROP VIEW batch_drop_v;
+CREATE VIEW batch_after_drop_v AS
+SELECT year, SUM(amount) AS MEASURE after_drop_revenue
+FROM sales;
+
+query IR rowsort
+SELECT year, AGGREGATE(after_drop_revenue) FROM batch_after_drop_v;
+----
+2022	150.0
+2023	225.0
+
+statement error
+SELECT year, AGGREGATE(dropped_revenue) AT (ALL)
+FROM batch_after_drop_v
+GROUP BY year;
+----
+Binder Error
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -349,7 +349,7 @@ SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year,
        AGGREGATE(revenue) AS revenue
 FROM sales_v;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used.*|syntax error at or near "extract_unused_revenue").*
 
 # =============================================================================
 # Test: CTE with AGGREGATE

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -181,6 +181,13 @@ SELECT year, revenue FROM batch_temp_result;
 2022	150.0
 2023	225.0
 
+statement error
+SELECT year, AGGREGATE(temp_revenue) AS revenue
+FROM batch_temp_v
+GROUP BY year;
+----
+Table with name batch_temp_v does not exist
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -212,6 +212,22 @@ SELECT year, revenue FROM batch_temp_cte_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE TEMP VIEW batch_temp_derived_v AS
+SELECT year, SUM(amount) AS MEASURE temp_derived_revenue
+FROM sales;
+CREATE TABLE batch_temp_derived_result AS
+SELECT *
+FROM (
+    SELECT AGGREGATE(temp_derived_revenue) AS revenue
+    FROM batch_temp_derived_v
+) s;
+
+query R
+SELECT revenue FROM batch_temp_derived_result;
+----
+375.0
+
 query IR rowsort
 CREATE VIEW batch_select_v AS
 SELECT year, SUM(amount) AS MEASURE batch_select_revenue

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -183,6 +183,24 @@ SELECT year, revenue FROM batch_temp_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE TEMP VIEW batch_temp_cte_v AS
+SELECT year, SUM(amount) AS MEASURE temp_cte_revenue
+FROM sales;
+CREATE TABLE batch_temp_cte_result AS
+WITH x AS (
+    SELECT year, AGGREGATE(temp_cte_revenue) AS revenue
+    FROM batch_temp_cte_v
+    GROUP BY year
+)
+SELECT * FROM x;
+
+query IR rowsort
+SELECT year, revenue FROM batch_temp_cte_result;
+----
+2022	150.0
+2023	225.0
+
 query IR rowsort
 CREATE VIEW batch_select_v AS
 SELECT year, SUM(amount) AS MEASURE batch_select_revenue

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -314,6 +314,22 @@ SELECT year, revenue FROM batch_qualified_shadow_drop_result;
 2022	6000.0
 2023	9000.0
 
+statement ok
+CREATE VIEW batch_drop_temp_direct_v AS
+SELECT year, SUM(amount) AS MEASURE drop_temp_direct_permanent_revenue
+FROM sales;
+
+statement error
+DROP VIEW batch_drop_temp_direct_v;
+CREATE TEMP VIEW batch_drop_temp_direct_v AS
+SELECT year, SUM(amount * 10) AS MEASURE drop_temp_direct_revenue
+FROM sales;
+SELECT year, AGGREGATE(drop_temp_direct_revenue) AS revenue
+FROM batch_drop_temp_direct_v
+GROUP BY year;
+----
+<REGEX>:.*TEMPORARY AS MEASURE views.*
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -50,6 +50,27 @@ SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
 2023	EU	75.0
 2023	US	150.0
 
+# Multi-statement batches should rewrite and register each measure view independently
+statement ok
+CREATE VIEW batch_orders_v AS
+SELECT year, SUM(amount) AS MEASURE order_revenue
+FROM sales;
+CREATE VIEW batch_regions_v AS
+SELECT region, SUM(amount) AS MEASURE regional_revenue
+FROM sales;
+
+query IR rowsort
+SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;
+----
+2022	150.0
+2023	225.0
+
+query TR rowsort
+SELECT region, AGGREGATE(regional_revenue) FROM batch_regions_v;
+----
+EU	125.0
+US	250.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -144,13 +144,15 @@ FROM sales;
 CREATE TABLE batch_order_result AS
 SELECT year, AGGREGATE(order_sensitive_revenue) AS revenue
 FROM batch_order_v;
-DROP VIEW batch_order_v;
 
 query IR rowsort
 SELECT year, revenue FROM batch_order_result;
 ----
 2022	150.0
 2023	225.0
+
+statement ok
+DROP VIEW batch_order_v;
 
 statement ok
 -- leading comment should not prevent measure registration

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -319,16 +319,26 @@ CREATE VIEW batch_drop_temp_direct_v AS
 SELECT year, SUM(amount) AS MEASURE drop_temp_direct_permanent_revenue
 FROM sales;
 
-statement error
+statement ok
 DROP VIEW batch_drop_temp_direct_v;
 CREATE TEMP VIEW batch_drop_temp_direct_v AS
 SELECT year, SUM(amount * 10) AS MEASURE drop_temp_direct_revenue
 FROM sales;
+CREATE TABLE batch_drop_temp_direct_result AS
 SELECT year, AGGREGATE(drop_temp_direct_revenue) AS revenue
 FROM batch_drop_temp_direct_v
 GROUP BY year;
+
+query IR rowsort
+SELECT year, revenue FROM batch_drop_temp_direct_result;
 ----
-<REGEX>:.*TEMPORARY AS MEASURE views.*
+2022	1500.0
+2023	2250.0
+
+statement error
+SELECT AGGREGATE(drop_temp_direct_revenue) FROM batch_drop_temp_direct_v;
+----
+<REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
 
 # =============================================================================
 # Test: CTE with AGGREGATE

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -80,6 +80,20 @@ SELECT region, AGGREGATE(regional_revenue) FROM batch_regions_v;
 EU	125.0
 US	250.0
 
+statement ok
+CREATE VIEW batch_inline_v AS
+SELECT year, SUM(amount) AS MEASURE inline_revenue
+FROM sales;
+CREATE TABLE batch_inline_result AS
+SELECT year, AGGREGATE(inline_revenue) AS revenue
+FROM batch_inline_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_inline_result;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -52,12 +52,21 @@ SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
 
 # Multi-statement batches should rewrite and register each measure view independently
 statement ok
+CREATE TABLE batch_notes(note TEXT);
+
+statement ok
+INSERT INTO batch_notes VALUES ($$a;b$$);
 CREATE VIEW batch_orders_v AS
 SELECT year, SUM(amount) AS MEASURE order_revenue
 FROM sales;
 CREATE VIEW batch_regions_v AS
 SELECT region, SUM(amount) AS MEASURE regional_revenue
 FROM sales;
+
+query T
+SELECT note FROM batch_notes;
+----
+a;b
 
 query IR rowsort
 SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -50,6 +50,11 @@ SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
 2023	EU	75.0
 2023	US	150.0
 
+query RI
+SELECT AGGREGATE(revenue), 1 AS measure FROM sales_v;
+----
+375.0	1
+
 # Multi-statement batches should rewrite and register each measure view independently
 statement ok
 CREATE TABLE batch_notes(note TEXT);

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -340,6 +340,17 @@ SELECT AGGREGATE(drop_temp_direct_revenue) FROM batch_drop_temp_direct_v;
 ----
 <REGEX>:.*(Catalog Error|Binder Error|Invalid Input Error).*
 
+statement error
+CREATE TEMP VIEW batch_extract_unused_tmp_v AS
+SELECT year, SUM(amount) AS MEASURE extract_unused_revenue
+FROM sales;
+CREATE TABLE batch_extract_unused_result AS
+SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year,
+       AGGREGATE(revenue) AS revenue
+FROM sales_v;
+----
+TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -87,6 +87,17 @@ SELECT note FROM batch_literal_notes;
 ----
 AGGREGATE(literal_revenue)
 
+statement ok
+CREATE VIEW batch_at_literal_v AS
+SELECT year, SUM(amount) AS MEASURE at_literal_revenue
+FROM sales;
+INSERT INTO batch_literal_notes VALUES ($$at_literal_revenue AT (ALL)$$);
+
+query T
+SELECT note FROM batch_literal_notes WHERE note = 'at_literal_revenue AT (ALL)';
+----
+at_literal_revenue AT (ALL)
+
 query IR rowsort
 SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;
 ----

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -253,6 +253,26 @@ GROUP BY year;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE VIEW batch_qualified_shadow_drop_v AS
+SELECT year, SUM(amount) AS MEASURE qualified_shadow_revenue
+FROM sales;
+
+statement ok
+CREATE TEMP VIEW batch_qualified_shadow_drop_v AS
+SELECT year, SUM(amount * 40) AS MEASURE qualified_shadow_revenue
+FROM sales;
+DROP VIEW main.batch_qualified_shadow_drop_v;
+CREATE TABLE batch_qualified_shadow_drop_result AS
+SELECT year, AGGREGATE(qualified_shadow_revenue) AS revenue
+FROM batch_qualified_shadow_drop_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_qualified_shadow_drop_result;
+----
+2022	6000.0
+2023	9000.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -195,6 +195,33 @@ FROM sales;
 ----
 TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
 
+statement ok
+CREATE VIEW batch_shadow_v AS
+SELECT year, SUM(amount) AS MEASURE shadow_revenue
+FROM sales;
+
+statement ok
+CREATE TEMP VIEW batch_shadow_v AS
+SELECT year, SUM(amount * 10) AS MEASURE shadow_revenue
+FROM sales;
+CREATE TABLE batch_shadow_temp_result AS
+SELECT year, AGGREGATE(shadow_revenue) AS revenue
+FROM batch_shadow_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_shadow_temp_result;
+----
+2022	1500.0
+2023	2250.0
+
+query IR rowsort
+SELECT year, AGGREGATE(shadow_revenue) AS revenue
+FROM batch_shadow_v
+GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -73,6 +73,20 @@ SELECT note FROM batch_notes;
 ----
 a;b
 
+statement ok
+CREATE TABLE batch_literal_notes(note TEXT);
+
+statement ok
+CREATE VIEW batch_literal_v AS
+SELECT year, SUM(amount) AS MEASURE literal_revenue
+FROM sales;
+INSERT INTO batch_literal_notes VALUES ($$AGGREGATE(literal_revenue)$$);
+
+query T
+SELECT note FROM batch_literal_notes;
+----
+AGGREGATE(literal_revenue)
+
 query IR rowsort
 SELECT year, AGGREGATE(order_revenue) FROM batch_orders_v;
 ----

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -181,6 +181,17 @@ SELECT year, revenue FROM batch_temp_result;
 2022	150.0
 2023	225.0
 
+query IR rowsort
+CREATE VIEW batch_select_v AS
+SELECT year, SUM(amount) AS MEASURE batch_select_revenue
+FROM sales;
+SELECT year, AGGREGATE(batch_select_revenue) AS revenue
+FROM batch_select_v
+GROUP BY year;
+----
+2022	150.0
+2023	225.0
+
 statement error
 SELECT year, AGGREGATE(temp_revenue) AS revenue
 FROM batch_temp_v

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -206,7 +206,7 @@ CREATE TEMP VIEW batch_temp_standalone_v AS
 SELECT year, SUM(amount) AS MEASURE standalone_temp_revenue
 FROM sales;
 ----
-TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE()
+<REGEX>:.*(TEMPORARY AS MEASURE views must be used in the same statement batch as AGGREGATE\(\)|Parser Error).*
 
 statement ok
 CREATE VIEW batch_shadow_v AS

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -254,6 +254,36 @@ GROUP BY year;
 2023	225.0
 
 statement ok
+CREATE VIEW batch_qualified_read_v AS
+SELECT year, SUM(amount) AS MEASURE qualified_read_revenue
+FROM sales;
+
+statement ok
+CREATE TEMP VIEW batch_qualified_read_v AS
+SELECT year, SUM(amount * 50) AS MEASURE qualified_read_revenue
+FROM sales;
+CREATE TABLE batch_qualified_permanent_read_result AS
+SELECT year, AGGREGATE(qualified_read_revenue) AS revenue
+FROM main.batch_qualified_read_v
+GROUP BY year;
+CREATE TABLE batch_qualified_temp_read_result AS
+SELECT year, AGGREGATE(qualified_read_revenue) AS revenue
+FROM batch_qualified_read_v
+GROUP BY year;
+
+query IR rowsort
+SELECT year, revenue FROM batch_qualified_permanent_read_result;
+----
+2022	150.0
+2023	225.0
+
+query IR rowsort
+SELECT year, revenue FROM batch_qualified_temp_read_result;
+----
+2022	7500.0
+2023	11250.0
+
+statement ok
 CREATE VIEW batch_qualified_shadow_drop_v AS
 SELECT year, SUM(amount) AS MEASURE qualified_shadow_revenue
 FROM sales;

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -123,6 +123,36 @@ GROUP BY year;
 ----
 Binder Error
 
+statement ok
+CREATE VIEW batch_order_v AS
+SELECT year, SUM(amount) AS MEASURE order_sensitive_revenue
+FROM sales;
+CREATE TABLE batch_order_result AS
+SELECT year, AGGREGATE(order_sensitive_revenue) AS revenue
+FROM batch_order_v;
+DROP VIEW batch_order_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_order_result;
+----
+2022	150.0
+2023	225.0
+
+statement ok
+-- leading comment should not prevent measure registration
+CREATE VIEW batch_comment_v AS
+SELECT year, SUM(amount) AS MEASURE comment_revenue
+FROM sales;
+CREATE TABLE batch_comment_result AS
+SELECT year, AGGREGATE(comment_revenue) AS revenue
+FROM batch_comment_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_comment_result;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -153,6 +153,20 @@ SELECT year, revenue FROM batch_comment_result;
 2022	150.0
 2023	225.0
 
+statement ok
+CREATE TEMP VIEW batch_temp_v AS
+SELECT year, SUM(amount) AS MEASURE temp_revenue
+FROM sales;
+CREATE TABLE batch_temp_result AS
+SELECT year, AGGREGATE(temp_revenue) AS revenue
+FROM batch_temp_v;
+
+query IR rowsort
+SELECT year, revenue FROM batch_temp_result;
+----
+2022	150.0
+2023	225.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -345,9 +345,11 @@ CREATE TEMP VIEW batch_extract_unused_tmp_v AS
 SELECT year, SUM(amount) AS MEASURE extract_unused_revenue
 FROM sales;
 CREATE TABLE batch_extract_unused_result AS
-SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year,
-       AGGREGATE(revenue) AS revenue
-FROM sales_v;
+WITH x AS (
+    SELECT EXTRACT(year FROM batch_extract_unused_tmp_v) AS extracted_year
+)
+SELECT x.extracted_year, AGGREGATE(revenue) AS revenue
+FROM x, sales_v;
 ----
 <REGEX>:.*(TEMPORARY AS MEASURE views must be used.*|syntax error at or near "extract_unused_revenue").*
 

--- a/yardstick-rs/src/ffi.rs
+++ b/yardstick-rs/src/ffi.rs
@@ -151,6 +151,13 @@ pub extern "C" fn yardstick_snapshot_measure_view(view_name: *const c_char) -> *
     Box::into_raw(Box::new(snapshot)) as *mut c_void
 }
 
+/// Create a snapshot representing an absent catalog entry.
+#[no_mangle]
+pub extern "C" fn yardstick_empty_measure_view_snapshot() -> *mut c_void {
+    let snapshot: Option<MeasureView> = None;
+    Box::into_raw(Box::new(snapshot)) as *mut c_void
+}
+
 /// Restore a previously snapped catalog entry, or drop the view if it did not exist.
 #[no_mangle]
 pub extern "C" fn yardstick_restore_measure_view_snapshot(

--- a/yardstick-rs/src/ffi.rs
+++ b/yardstick-rs/src/ffi.rs
@@ -11,11 +11,11 @@ use std::os::raw::{c_char, c_void};
 use std::ptr;
 
 use crate::sql::{
-    drop_measure_view_from_sql, expand_aggregate_with_at, expand_curly_braces,
-    drop_measure_view, extract_view_name, get_measure_aggregation, get_measure_view,
+    drop_measure_view, drop_measure_view_from_sql, expand_aggregate_with_at, expand_curly_braces,
+    extract_drop_view_name, extract_view_name, get_measure_aggregation, get_measure_view,
     has_aggregate_function, has_as_measure, has_at_syntax, has_curly_brace_measure,
-    has_implicit_measure_refs, has_measure_at_refs,
-    process_create_view, restore_measure_view, MeasureView,
+    has_implicit_measure_refs, has_measure_at_refs, process_create_view, restore_measure_view,
+    MeasureView,
 };
 
 /// Result from processing CREATE VIEW with AS MEASURE
@@ -110,6 +110,25 @@ pub extern "C" fn yardstick_extract_view_name(sql: *const c_char) -> *mut c_char
     };
 
     extract_view_name(sql_str)
+        .map(|name| to_c_string(&name))
+        .unwrap_or(ptr::null_mut())
+}
+
+/// Extract the view name from a DROP VIEW statement.
+#[no_mangle]
+pub extern "C" fn yardstick_extract_drop_view_name(sql: *const c_char) -> *mut c_char {
+    if sql.is_null() {
+        return ptr::null_mut();
+    }
+
+    let sql_str = unsafe {
+        match CStr::from_ptr(sql).to_str() {
+            Ok(s) => s,
+            Err(_) => return ptr::null_mut(),
+        }
+    };
+
+    extract_drop_view_name(sql_str)
         .map(|name| to_c_string(&name))
         .unwrap_or(ptr::null_mut())
 }

--- a/yardstick-rs/src/ffi.rs
+++ b/yardstick-rs/src/ffi.rs
@@ -7,14 +7,15 @@
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 use std::ptr;
 
 use crate::sql::{
     drop_measure_view_from_sql, expand_aggregate_with_at, expand_curly_braces,
-    get_measure_aggregation, has_aggregate_function, has_as_measure, has_at_syntax,
-    has_curly_brace_measure, process_create_view,
+    drop_measure_view, extract_view_name, get_measure_aggregation, get_measure_view,
+    has_aggregate_function, has_as_measure, has_at_syntax, has_curly_brace_measure,
     has_implicit_measure_refs, has_measure_at_refs,
+    process_create_view, restore_measure_view, MeasureView,
 };
 
 /// Result from processing CREATE VIEW with AS MEASURE
@@ -92,6 +93,80 @@ pub extern "C" fn yardstick_drop_measure_view_from_sql(sql: *const c_char) -> bo
     };
 
     drop_measure_view_from_sql(sql_str)
+}
+
+/// Extract the view name from a CREATE VIEW statement.
+#[no_mangle]
+pub extern "C" fn yardstick_extract_view_name(sql: *const c_char) -> *mut c_char {
+    if sql.is_null() {
+        return ptr::null_mut();
+    }
+
+    let sql_str = unsafe {
+        match CStr::from_ptr(sql).to_str() {
+            Ok(s) => s,
+            Err(_) => return ptr::null_mut(),
+        }
+    };
+
+    extract_view_name(sql_str)
+        .map(|name| to_c_string(&name))
+        .unwrap_or(ptr::null_mut())
+}
+
+/// Snapshot a measure view catalog entry before a speculative rewrite mutates it.
+#[no_mangle]
+pub extern "C" fn yardstick_snapshot_measure_view(view_name: *const c_char) -> *mut c_void {
+    if view_name.is_null() {
+        return ptr::null_mut();
+    }
+
+    let view_name_str = unsafe {
+        match CStr::from_ptr(view_name).to_str() {
+            Ok(s) => s,
+            Err(_) => return ptr::null_mut(),
+        }
+    };
+
+    let snapshot: Option<MeasureView> = get_measure_view(view_name_str);
+    Box::into_raw(Box::new(snapshot)) as *mut c_void
+}
+
+/// Restore a previously snapped catalog entry, or drop the view if it did not exist.
+#[no_mangle]
+pub extern "C" fn yardstick_restore_measure_view_snapshot(
+    view_name: *const c_char,
+    snapshot: *mut c_void,
+) {
+    if view_name.is_null() || snapshot.is_null() {
+        return;
+    }
+
+    let view_name_str = unsafe {
+        match CStr::from_ptr(view_name).to_str() {
+            Ok(s) => s,
+            Err(_) => return,
+        }
+    };
+
+    let snapshot = unsafe { Box::from_raw(snapshot as *mut Option<MeasureView>) };
+    match *snapshot {
+        Some(view) => restore_measure_view(view),
+        None => {
+            drop_measure_view(view_name_str);
+        }
+    }
+}
+
+/// Free a measure view snapshot without restoring it.
+#[no_mangle]
+pub extern "C" fn yardstick_free_measure_view_snapshot(snapshot: *mut c_void) {
+    if snapshot.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(snapshot as *mut Option<MeasureView>));
+    }
 }
 
 /// Check if SQL contains curly brace measure syntax: `{column}`

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -1187,24 +1187,155 @@ fn aggregate_with_at(input: &str) -> IResult<&str, (&str, Vec<ContextModifier>)>
 }
 
 /// Extract all AGGREGATE(...) [AT (...)]+ patterns from SQL with full modifier list
+fn aggregate_call_starts_outside_literals(sql: &str) -> Vec<usize> {
+    let bytes = sql.as_bytes();
+    let len = bytes.len();
+    let mut starts = Vec::new();
+    let mut i = 0;
+
+    let is_ident_start = |b: u8| b.is_ascii_alphabetic() || b == b'_';
+    let is_ident_char = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let skip_whitespace = |mut idx: usize| -> usize {
+        while idx < len && bytes[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        idx
+    };
+
+    while i < len {
+        match bytes[i] {
+            b'\'' => {
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\'' {
+                        if i + 1 < len && bytes[i + 1] == b'\'' {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'"' => {
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'"' {
+                        if i + 1 < len && bytes[i + 1] == b'"' {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'-' if i + 1 < len && bytes[i + 1] == b'-' => {
+                i += 2;
+                while i < len && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < len {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b'$' => {
+                let tag_start = i;
+                let mut tag_end = i + 1;
+                while tag_end < len && is_ident_char(bytes[tag_end]) {
+                    tag_end += 1;
+                }
+                if tag_end < len && bytes[tag_end] == b'$' {
+                    let tag = &sql[tag_start..tag_end + 1];
+                    if let Some(end_offset) = sql[tag_end + 1..].find(tag) {
+                        i = tag_end + 1 + end_offset + tag.len();
+                    } else {
+                        i = tag_end + 1;
+                    }
+                } else {
+                    i += 1;
+                }
+            }
+            b if is_ident_start(b) => {
+                let mut token_start = i;
+                let mut token_end = i + 1;
+                while token_end < len && is_ident_char(bytes[token_end]) {
+                    token_end += 1;
+                }
+
+                let mut pos = token_end;
+                loop {
+                    pos = skip_whitespace(pos);
+                    if pos >= len || bytes[pos] != b'.' {
+                        break;
+                    }
+                    pos += 1;
+                    pos = skip_whitespace(pos);
+                    if pos < len && is_ident_start(bytes[pos]) {
+                        token_start = pos;
+                        token_end = pos + 1;
+                        while token_end < len && is_ident_char(bytes[token_end]) {
+                            token_end += 1;
+                        }
+                        pos = token_end;
+                    } else if pos < len && bytes[pos] == b'"' {
+                        pos += 1;
+                        while pos < len {
+                            if bytes[pos] == b'"' {
+                                if pos + 1 < len && bytes[pos + 1] == b'"' {
+                                    pos += 2;
+                                } else {
+                                    pos += 1;
+                                    break;
+                                }
+                            } else {
+                                pos += 1;
+                            }
+                        }
+                    } else {
+                        break;
+                    }
+                }
+
+                let after_ws = skip_whitespace(pos);
+                if after_ws < len
+                    && bytes[after_ws] == b'('
+                    && sql[token_start..token_end].eq_ignore_ascii_case("AGGREGATE")
+                {
+                    starts.push(token_start);
+                }
+                i = pos;
+            }
+            _ => i += 1,
+        }
+    }
+
+    starts
+}
+
 pub fn extract_aggregate_with_at_full(
     sql: &str,
 ) -> Vec<(String, Vec<ContextModifier>, usize, usize)> {
     let mut results = Vec::new();
-    let sql_upper = sql.to_uppercase();
-    let mut search_pos = 0;
 
-    while let Some(agg_offset) = sql_upper[search_pos..].find("AGGREGATE") {
-        let start = search_pos + agg_offset;
-
+    for start in aggregate_call_starts_outside_literals(sql) {
         if let Ok((remaining, (measure, modifiers))) = aggregate_with_at(&sql[start..]) {
             if !modifiers.is_empty() {
                 let end = sql.len() - remaining.len();
                 results.push((measure.to_string(), modifiers, start, end));
             }
         }
-
-        search_pos = start + 1;
     }
 
     results
@@ -1237,12 +1368,8 @@ pub fn extract_aggregate_with_at(sql: &str) -> Vec<(String, ContextModifier, usi
 /// Extract all AGGREGATE() calls without AT
 pub fn extract_all_aggregate_calls(sql: &str) -> Vec<(String, usize, usize)> {
     let mut results = Vec::new();
-    let sql_upper = sql.to_uppercase();
-    let mut search_pos = 0;
 
-    while let Some(agg_offset) = sql_upper[search_pos..].find("AGGREGATE") {
-        let start = search_pos + agg_offset;
-
+    for start in aggregate_call_starts_outside_literals(sql) {
         if let Ok((remaining, (measure, modifiers))) = aggregate_with_at(&sql[start..]) {
             // Only include calls WITHOUT AT modifier, and only when the argument
             // is a simple identifier (measure name). This avoids intercepting
@@ -1252,8 +1379,6 @@ pub fn extract_all_aggregate_calls(sql: &str) -> Vec<(String, usize, usize)> {
                 results.push((measure.to_string(), start, end));
             }
         }
-
-        search_pos = start + 1;
     }
 
     results
@@ -6909,6 +7034,24 @@ FROM orders"#;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, "revenue");
         assert_eq!(results[0].1, ContextModifier::All("status".to_string()));
+    }
+
+    #[test]
+    fn test_extract_aggregate_skips_dollar_quoted_literals() {
+        assert!(extract_all_aggregate_calls(
+            "SELECT $$AGGREGATE(revenue)$$ AS note"
+        )
+        .is_empty());
+        assert!(extract_aggregate_with_at_full(
+            "SELECT $tag$AGGREGATE(revenue) AT (ALL)$tag$ AS note"
+        )
+        .is_empty());
+
+        let calls = extract_all_aggregate_calls(
+            "SELECT AGGREGATE(revenue), $$AGGREGATE(cost)$$ FROM sales_v",
+        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "revenue");
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -6327,6 +6327,7 @@ pub fn store_measure_view(
     };
 
     let mut views = MEASURE_VIEWS.lock().unwrap();
+    remove_measure_view_case_insensitive(&mut views, view_name);
     views.insert(view_name.to_string(), measure_view);
 }
 
@@ -6340,6 +6341,7 @@ pub fn get_measure_view(view_name: &str) -> Option<MeasureView> {
 
 pub fn restore_measure_view(view: MeasureView) {
     let mut views = MEASURE_VIEWS.lock().unwrap();
+    remove_measure_view_case_insensitive(&mut views, &view.view_name);
     views.insert(view.view_name.clone(), view);
 }
 
@@ -6490,6 +6492,21 @@ fn is_literal_constant(expr: &str) -> bool {
         }
     }
 
+    false
+}
+
+fn remove_measure_view_case_insensitive(
+    views: &mut HashMap<String, MeasureView>,
+    view_name: &str,
+) -> bool {
+    let key = views
+        .keys()
+        .find(|name| name.eq_ignore_ascii_case(view_name))
+        .cloned();
+    if let Some(key) = key {
+        views.remove(&key);
+        return true;
+    }
     false
 }
 
@@ -7365,6 +7382,38 @@ FROM orders"#;
         assert!(get_measure_view("orders_v").is_some());
         assert!(drop_measure_view_from_sql("DROP VIEW orders_v;"));
         assert!(get_measure_view("orders_v").is_none());
+
+        store_measure_view(
+            "sales_v",
+            vec![ViewMeasure {
+                column_name: "new_revenue".to_string(),
+                expression: "SUM(new_amount)".to_string(),
+                is_decomposable: true,
+            }],
+            "SELECT year, SUM(new_amount) AS new_revenue FROM sales GROUP BY year",
+            Some("sales".to_string()),
+        );
+        restore_measure_view(MeasureView {
+            view_name: "Sales_V".to_string(),
+            measures: vec![ViewMeasure {
+                column_name: "revenue".to_string(),
+                expression: "SUM(amount)".to_string(),
+                is_decomposable: true,
+            }],
+            base_query: "SELECT year, SUM(amount) AS revenue FROM sales GROUP BY year".to_string(),
+            base_table: Some("sales".to_string()),
+            base_relation_sql: None,
+            dimension_exprs: HashMap::new(),
+            group_by_cols: vec!["year".to_string()],
+        });
+        let restored = get_measure_view("sales_v").unwrap();
+        assert_eq!(restored.view_name, "Sales_V");
+        assert_eq!(restored.measures[0].column_name, "revenue");
+        let views = MEASURE_VIEWS.lock().unwrap();
+        assert!(views.contains_key("Sales_V"));
+        assert!(!views.contains_key("sales_v"));
+        drop(views);
+        clear_measure_views();
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -1469,7 +1469,13 @@ pub fn extract_drop_view_name(sql: &str) -> Option<String> {
     }
 
     let end = parse_qualified_name_span(sql, idx)?;
-    if !is_statement_tail(sql, end) {
+    let mut tail = skip_ws_and_comments(sql, end);
+    if matches_keyword_at(&upper, tail, "CASCADE") {
+        tail += "CASCADE".len();
+    } else if matches_keyword_at(&upper, tail, "RESTRICT") {
+        tail += "RESTRICT".len();
+    }
+    if !is_statement_tail(sql, tail) {
         return None;
     }
     extract_last_qualified_identifier(&sql[idx..end])
@@ -7370,6 +7376,14 @@ FROM orders"#;
         assert_eq!(
             extract_drop_view_name("DROP VIEW /* keep */ IF EXISTS [dbo].[Orders View]"),
             Some("Orders View".to_string())
+        );
+        assert_eq!(
+            extract_drop_view_name("DROP VIEW orders_v CASCADE"),
+            Some("orders_v".to_string())
+        );
+        assert_eq!(
+            extract_drop_view_name("DROP VIEW orders_v RESTRICT;"),
+            Some("orders_v".to_string())
         );
         assert_eq!(extract_drop_view_name("DROP VIEW orders_v extra"), None);
     }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -312,6 +312,26 @@ pub fn has_aggregate_function(sql: &str) -> bool {
                     i += 1;
                 }
             }
+            '$' => {
+                let tag_start = i;
+                let mut tag_end = i + 1;
+                while tag_end < len && is_ident_char(chars[tag_end]) {
+                    tag_end += 1;
+                }
+                if tag_end < len && chars[tag_end] == '$' {
+                    let tag: Vec<char> = chars[tag_start..=tag_end].to_vec();
+                    i = tag_end + 1;
+                    while i + tag.len() <= len {
+                        if chars[i..i + tag.len()] == tag[..] {
+                            i += tag.len();
+                            break;
+                        }
+                        i += 1;
+                    }
+                } else {
+                    i += 1;
+                }
+            }
             '"' => {
                 let (token, next) = parse_quoted_identifier(i + 1);
                 let (last, after_chain) = parse_qualified_chain(token, next);
@@ -6605,6 +6625,10 @@ mod tests {
         assert!(has_aggregate_function("SELECT schema.AGGREGATE(revenue) FROM foo"));
         assert!(has_aggregate_function(
             "SELECT \"schema\".\"AGGREGATE\" (revenue) FROM foo"
+        ));
+        assert!(!has_aggregate_function("SELECT $$AGGREGATE(revenue)$$ AS note"));
+        assert!(!has_aggregate_function(
+            "SELECT $tag$AGGREGATE(revenue) AT (ALL)$tag$ AS note"
         ));
         assert!(!has_aggregate_function("SELECT TOTAL_AGGREGATE(revenue) FROM foo"));
         assert!(!has_aggregate_function("SELECT \"TOTAL_AGGREGATE\"(revenue) FROM foo"));

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -1277,6 +1277,12 @@ fn create_view_header(input: &str) -> IResult<&str, &str> {
         multispace1,
     )))(input)?;
 
+    // Optional TEMP/TEMPORARY
+    let (input, _) = opt(tuple((
+        alt((tag_no_case("TEMPORARY"), tag_no_case("TEMP"))),
+        multispace1,
+    )))(input)?;
+
     let (input, _) = tag_no_case("VIEW")(input)?;
     let (input, _) = multispace1(input)?;
     let (input, name) = identifier(input)?;
@@ -7144,6 +7150,14 @@ FROM orders"#;
         assert_eq!(
             extract_view_name("CREATE OR REPLACE VIEW bar AS SELECT 1"),
             Some("bar".to_string())
+        );
+        assert_eq!(
+            extract_view_name("CREATE TEMP VIEW temp_foo AS SELECT 1"),
+            Some("temp_foo".to_string())
+        );
+        assert_eq!(
+            extract_view_name("CREATE OR REPLACE TEMPORARY VIEW temp_bar AS SELECT 1"),
+            Some("temp_bar".to_string())
         );
     }
 

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -892,6 +892,24 @@ fn rewrite_measure_at_refs(sql: &str) -> String {
                 }
                 continue;
             }
+            b'$' => {
+                let mut tag_end = i + 1;
+                while tag_end < bytes.len() && bytes[tag_end] != b'$' {
+                    let tag_char = bytes[tag_end];
+                    if !tag_char.is_ascii_alphanumeric() && tag_char != b'_' {
+                        break;
+                    }
+                    tag_end += 1;
+                }
+                if tag_end < bytes.len() && bytes[tag_end] == b'$' {
+                    let tag = &sql[i..=tag_end];
+                    i = tag_end + 1;
+                    if let Some(relative_end) = sql[i..].find(tag) {
+                        i += relative_end + tag.len();
+                    }
+                    continue;
+                }
+            }
             _ => {}
         }
 
@@ -7293,6 +7311,26 @@ FROM orders"#;
         let rewritten = rewrite_measure_at_refs(sql);
         assert_eq!(rewritten, "SELECT AGGREGATE(revenue) AT (VISIBLE) FROM sales_v");
         assert!(has_measure_at_refs(sql));
+    }
+
+    #[test]
+    #[serial]
+    fn test_rewrite_measure_at_refs_skips_dollar_literals() {
+        clear_measure_views();
+        store_measure_view(
+            "sales_v",
+            vec![ViewMeasure {
+                column_name: "revenue".to_string(),
+                expression: "SUM(amount)".to_string(),
+                is_decomposable: true,
+            }],
+            "SELECT year, SUM(amount) AS revenue FROM sales GROUP BY year",
+            Some("sales".to_string()),
+        );
+
+        let sql = "INSERT INTO notes VALUES ($tag$revenue AT (ALL)$tag$)";
+        assert_eq!(rewrite_measure_at_refs(sql), sql);
+        assert!(!has_measure_at_refs(sql));
     }
 
     #[test]

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -6332,7 +6332,10 @@ pub fn store_measure_view(
 
 pub fn get_measure_view(view_name: &str) -> Option<MeasureView> {
     let views = MEASURE_VIEWS.lock().unwrap();
-    views.get(view_name).cloned()
+    views
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(view_name))
+        .map(|(_, view)| view.clone())
 }
 
 pub fn restore_measure_view(view: MeasureView) {
@@ -7344,7 +7347,7 @@ FROM orders"#;
     fn test_drop_measure_view_from_sql() {
         clear_measure_views();
         store_measure_view(
-            "orders_v",
+            "Orders_V",
             vec![ViewMeasure {
                 column_name: "revenue".to_string(),
                 expression: "SUM(amount)".to_string(),
@@ -7355,6 +7358,7 @@ FROM orders"#;
         );
 
         assert!(get_measure_view("orders_v").is_some());
+        assert!(get_measure_view("ORDERS_V").is_some());
         assert!(!drop_measure_view_from_sql(
             "DROP VIEW orders_v /* invalid tail */ extra"
         ));

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -6329,6 +6329,11 @@ pub fn get_measure_view(view_name: &str) -> Option<MeasureView> {
     views.get(view_name).cloned()
 }
 
+pub fn restore_measure_view(view: MeasureView) {
+    let mut views = MEASURE_VIEWS.lock().unwrap();
+    views.insert(view.view_name.clone(), view);
+}
+
 pub fn clear_measure_views() {
     let mut views = MEASURE_VIEWS.lock().unwrap();
     views.clear();

--- a/yardstick-rs/src/sql/mod.rs
+++ b/yardstick-rs/src/sql/mod.rs
@@ -9,6 +9,7 @@ pub use measures::{
     expand_aggregate,
     expand_aggregate_with_at,
     expand_curly_braces,
+    extract_drop_view_name,
     extract_view_name,
     // Measure lookup
     get_measure_aggregation,

--- a/yardstick-rs/src/sql/mod.rs
+++ b/yardstick-rs/src/sql/mod.rs
@@ -4,12 +4,15 @@ pub mod measures;
 
 pub use measures::{
     // Processing functions
+    drop_measure_view,
     drop_measure_view_from_sql,
     expand_aggregate,
     expand_aggregate_with_at,
     expand_curly_braces,
+    extract_view_name,
     // Measure lookup
     get_measure_aggregation,
+    get_measure_view,
     // Detection functions
     has_aggregate_function,
     has_as_measure,
@@ -18,6 +21,7 @@ pub use measures::{
     has_implicit_measure_refs,
     has_measure_at_refs,
     process_create_view,
+    restore_measure_view,
     // Core types
     AggregateExpandResult,
     ContextModifier,


### PR DESCRIPTION
Fixes multi-statement SQL batches containing more than one CREATE VIEW ... AS MEASURE definition by rewriting and registering measure views statement-by-statement before DuckDB parses the cleaned batch.

Adds regression coverage for two AS MEASURE view definitions in one statement batch, then verifies both registered measures through prefixed and parser-override query paths.

Validation:
- git diff --check
- make test

Note: standalone cargo test is not a valid full-suite target in this checkout because many existing tests require the C++ parser FFI to be initialized by the extension runtime.