### PR TITLE
Sanitize non-ASCII SQL comments

### DIFF
--- a/src/yardstick_parser_ffi.cpp
+++ b/src/yardstick_parser_ffi.cpp
@@ -239,6 +239,14 @@ inline void YsPrependQualifier(ColumnRefExpression &c, const std::string &qualif
 #endif
 }
 
+inline const std::string &YsBaseTableName(const BaseTableRef &b) {
+#if YARDSTICK_NEW_EXPR_API
+    return b.Table().GetIdentifierName();
+#else
+    return b.table_name;
+#endif
+}
+
 } // namespace
 
 //=============================================================================
@@ -922,7 +930,7 @@ static void CollectTablesFromTableRef(TableRef* ref, std::vector<YardstickTableR
         case TableReferenceType::BASE_TABLE: {
             auto* base = static_cast<BaseTableRef*>(ref);
             YardstickTableRef t;
-            t.table_name = safe_strdup(YsName(base->table_name));
+            t.table_name = safe_strdup(YsBaseTableName(*base));
             t.alias = base->alias.empty() ? nullptr : safe_strdup(YsName(base->alias));
             t.is_subquery = false;
             tables.push_back(t);
@@ -1481,7 +1489,7 @@ static void CollectTableQualifiers(const TableRef *ref, TableQualifierSet &quali
         case TableReferenceType::BASE_TABLE: {
             auto *base = static_cast<const BaseTableRef*>(ref);
             if (ref->alias.empty()) {
-                AddTableQualifier(qualifiers, YsName(base->table_name));
+                AddTableQualifier(qualifiers, YsBaseTableName(*base));
             }
             break;
         }

--- a/test/sql/measures.test
+++ b/test/sql/measures.test
@@ -34,6 +34,22 @@ SEMANTIC SELECT year, region, AGGREGATE(revenue) FROM sales_v;
 2023	EU	75.0
 2023	US	150.0
 
+statement ok
+CREATE VIEW sales_unicode_comment_v AS
+SELECT
+    year,
+    region, -- café
+    SUM(amount) AS MEASURE revenue /* 東京 */
+FROM sales;
+
+query IIR rowsort
+SEMANTIC SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
+----
+2022	EU	50.0
+2022	US	100.0
+2023	EU	75.0
+2023	US	150.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/test/sql/no_semantic_prefix.test
+++ b/test/sql/no_semantic_prefix.test
@@ -34,6 +34,22 @@ SELECT year, region, AGGREGATE(revenue) FROM sales_v;
 2023	EU	75.0
 2023	US	150.0
 
+statement ok
+CREATE VIEW sales_unicode_comment_v AS
+SELECT
+    year,
+    region, -- café
+    SUM(amount) AS MEASURE revenue /* 東京 */
+FROM sales;
+
+query IIR rowsort
+SELECT year, region, AGGREGATE(revenue) FROM sales_unicode_comment_v;
+----
+2022	EU	50.0
+2022	US	100.0
+2023	EU	75.0
+2023	US	150.0
+
 # =============================================================================
 # Test: CTE with AGGREGATE
 # =============================================================================

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3634,11 +3634,25 @@ fn dollar_quote_delimiter_at(sql: &str, start: usize) -> Option<&str> {
     }
 }
 
+fn is_escape_string_quote_at(sql: &str, quote_pos: usize) -> bool {
+    let bytes = sql.as_bytes();
+    if quote_pos == 0 || quote_pos >= bytes.len() || bytes[quote_pos] != b'\'' {
+        return false;
+    }
+    let prefix_pos = quote_pos - 1;
+    if !matches!(bytes[prefix_pos], b'e' | b'E') {
+        return false;
+    }
+    prefix_pos == 0
+        || !(bytes[prefix_pos - 1].is_ascii_alphanumeric() || bytes[prefix_pos - 1] == b'_')
+}
+
 fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
     let bytes = sql.as_bytes();
     let mut out = String::with_capacity(sql.len());
     let mut i = 0;
     let mut in_single = false;
+    let mut single_allows_backslash = false;
     let mut in_double = false;
     let mut in_backtick = false;
     let mut in_dollar_quote: Option<String> = None;
@@ -3696,12 +3710,20 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
         if in_single {
             out.push(ch);
             i += ch.len_utf8();
+            if single_allows_backslash && ch == '\\' {
+                if let Some(next) = sql[i..].chars().next() {
+                    out.push(next);
+                    i += next.len_utf8();
+                }
+                continue;
+            }
             if ch == '\'' {
                 if i < bytes.len() && bytes[i] == b'\'' {
                     out.push('\'');
                     i += 1;
                 } else {
                     in_single = false;
+                    single_allows_backslash = false;
                 }
             }
             continue;
@@ -3757,7 +3779,10 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
         i += ch.len_utf8();
 
         match ch {
-            '\'' => in_single = true,
+            '\'' => {
+                in_single = true;
+                single_allows_backslash = is_escape_string_quote_at(sql, i - ch.len_utf8());
+            }
             '"' => in_double = true,
             '`' => in_backtick = true,
             _ => {}
@@ -6692,6 +6717,17 @@ FROM orders"#;
         let sanitized = sanitize_non_ascii_in_sql_comments(sql);
 
         assert!(sanitized.contains("[']']"));
+        assert!(!sanitized.ends_with("東京"));
+        assert!(sanitized.is_ascii());
+        assert_eq!(sanitized.len(), sql.len());
+    }
+
+    #[test]
+    fn test_comment_sanitizer_handles_escape_string_quotes() {
+        let sql = "SELECT E'can\\'t' AS label FROM sales -- 東京";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("E'can\\'t'"));
         assert!(!sanitized.ends_with("東京"));
         assert!(sanitized.is_ascii());
         assert_eq!(sanitized.len(), sql.len());

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3634,29 +3634,6 @@ fn dollar_quote_delimiter_at(sql: &str, start: usize) -> Option<&str> {
     }
 }
 
-fn is_bracket_quoted_identifier_at(sql: &str, start: usize) -> bool {
-    let bytes = sql.as_bytes();
-    if start >= bytes.len() || bytes[start] != b'[' {
-        return false;
-    }
-
-    let mut i = start + 1;
-    let content_start = i;
-    while i < bytes.len() {
-        if bytes[i] == b']' {
-            return i > content_start;
-        }
-        if i + 1 < bytes.len()
-            && ((bytes[i] == b'-' && bytes[i + 1] == b'-')
-                || (bytes[i] == b'/' && bytes[i + 1] == b'*'))
-        {
-            return false;
-        }
-        i += 1;
-    }
-    false
-}
-
 fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
     let bytes = sql.as_bytes();
     let mut out = String::with_capacity(sql.len());
@@ -3664,7 +3641,6 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
     let mut in_single = false;
     let mut in_double = false;
     let mut in_backtick = false;
-    let mut in_bracket = false;
     let mut in_dollar_quote: Option<String> = None;
     let mut in_line_comment = false;
     let mut block_comment_depth = 0usize;
@@ -3754,15 +3730,6 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
             continue;
         }
 
-        if in_bracket {
-            out.push(ch);
-            i += ch.len_utf8();
-            if ch == ']' {
-                in_bracket = false;
-            }
-            continue;
-        }
-
         if let Some(delimiter) = dollar_quote_delimiter_at(sql, i) {
             if sql[i + delimiter.len()..].contains(delimiter) {
                 out.push_str(delimiter);
@@ -3793,7 +3760,6 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
             '\'' => in_single = true,
             '"' => in_double = true,
             '`' => in_backtick = true,
-            '[' if is_bracket_quoted_identifier_at(sql, i - ch.len_utf8()) => in_bracket = true,
             _ => {}
         }
     }
@@ -6716,6 +6682,17 @@ FROM orders"#;
         assert!(sanitized.contains("[1, /*"));
         assert!(!sanitized.contains("東京"));
         assert!(!sanitized.ends_with("résumé"));
+        assert!(sanitized.is_ascii());
+        assert_eq!(sanitized.len(), sql.len());
+    }
+
+    #[test]
+    fn test_comment_sanitizer_handles_quotes_inside_list_brackets() {
+        let sql = "SELECT [']'] AS xs FROM t -- 東京";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("[']']"));
+        assert!(!sanitized.ends_with("東京"));
         assert!(sanitized.is_ascii());
         assert_eq!(sanitized.len(), sql.len());
     }

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3667,7 +3667,7 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
     let mut in_bracket = false;
     let mut in_dollar_quote: Option<String> = None;
     let mut in_line_comment = false;
-    let mut in_block_comment = false;
+    let mut block_comment_depth = 0usize;
 
     while i < bytes.len() {
         if let Some(ref delimiter) = in_dollar_quote {
@@ -3694,11 +3694,18 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
             continue;
         }
 
-        if in_block_comment {
+        if block_comment_depth > 0 {
+            if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+                out.push_str("/*");
+                i += 2;
+                block_comment_depth += 1;
+                continue;
+            }
+
             if i + 1 < bytes.len() && bytes[i] == b'*' && bytes[i + 1] == b'/' {
                 out.push_str("*/");
                 i += 2;
-                in_block_comment = false;
+                block_comment_depth -= 1;
                 continue;
             }
 
@@ -3775,7 +3782,7 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
         if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
             out.push_str("/*");
             i += 2;
-            in_block_comment = true;
+            block_comment_depth = 1;
             continue;
         }
 
@@ -6707,6 +6714,18 @@ FROM orders"#;
         let sanitized = sanitize_non_ascii_in_sql_comments(sql);
 
         assert!(sanitized.contains("[1, /*"));
+        assert!(!sanitized.contains("東京"));
+        assert!(!sanitized.ends_with("résumé"));
+        assert!(sanitized.is_ascii());
+        assert_eq!(sanitized.len(), sql.len());
+    }
+
+    #[test]
+    fn test_comment_sanitizer_handles_nested_block_comments() {
+        let sql = "SELECT 1 /* outer /* inner */ 東京 */ FROM t -- résumé";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("/* outer /* inner */"));
         assert!(!sanitized.contains("東京"));
         assert!(!sanitized.ends_with("résumé"));
         assert!(sanitized.is_ascii());

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3634,6 +3634,29 @@ fn dollar_quote_delimiter_at(sql: &str, start: usize) -> Option<&str> {
     }
 }
 
+fn is_bracket_quoted_identifier_at(sql: &str, start: usize) -> bool {
+    let bytes = sql.as_bytes();
+    if start >= bytes.len() || bytes[start] != b'[' {
+        return false;
+    }
+
+    let mut i = start + 1;
+    let content_start = i;
+    while i < bytes.len() {
+        if bytes[i] == b']' {
+            return i > content_start;
+        }
+        if i + 1 < bytes.len()
+            && ((bytes[i] == b'-' && bytes[i + 1] == b'-')
+                || (bytes[i] == b'/' && bytes[i + 1] == b'*'))
+        {
+            return false;
+        }
+        i += 1;
+    }
+    false
+}
+
 fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
     let bytes = sql.as_bytes();
     let mut out = String::with_capacity(sql.len());
@@ -3763,7 +3786,7 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
             '\'' => in_single = true,
             '"' => in_double = true,
             '`' => in_backtick = true,
-            '[' => in_bracket = true,
+            '[' if is_bracket_quoted_identifier_at(sql, i - ch.len_utf8()) => in_bracket = true,
             _ => {}
         }
     }
@@ -6675,6 +6698,28 @@ FROM orders"#;
         assert!(sanitized.contains("-- $tag$ caf"));
         assert!(!sanitized.ends_with("café"));
         assert!(sanitized.is_ascii());
+        assert_eq!(sanitized.len(), sql.len());
+    }
+
+    #[test]
+    fn test_comment_sanitizer_handles_comments_inside_list_brackets() {
+        let sql = "SELECT [1, /* 東京 */ 2] AS xs FROM t -- résumé";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("[1, /*"));
+        assert!(!sanitized.contains("東京"));
+        assert!(!sanitized.ends_with("résumé"));
+        assert!(sanitized.is_ascii());
+        assert_eq!(sanitized.len(), sql.len());
+    }
+
+    #[test]
+    fn test_comment_sanitizer_preserves_bracket_quoted_identifiers() {
+        let sql = "SELECT [東京] FROM t -- résumé";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("[東京]"));
+        assert!(!sanitized.ends_with("résumé"));
         assert_eq!(sanitized.len(), sql.len());
     }
 

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3616,6 +3616,24 @@ fn push_comment_char_sanitized(out: &mut String, ch: char) {
     }
 }
 
+fn dollar_quote_delimiter_at(sql: &str, start: usize) -> Option<&str> {
+    let bytes = sql.as_bytes();
+    if start >= bytes.len() || bytes[start] != b'$' {
+        return None;
+    }
+
+    let mut end = start + 1;
+    while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+        end += 1;
+    }
+
+    if end < bytes.len() && bytes[end] == b'$' {
+        Some(&sql[start..=end])
+    } else {
+        None
+    }
+}
+
 fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
     let bytes = sql.as_bytes();
     let mut out = String::with_capacity(sql.len());
@@ -3624,10 +3642,25 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
     let mut in_double = false;
     let mut in_backtick = false;
     let mut in_bracket = false;
+    let mut in_dollar_quote: Option<String> = None;
     let mut in_line_comment = false;
     let mut in_block_comment = false;
 
     while i < bytes.len() {
+        if let Some(ref delimiter) = in_dollar_quote {
+            if sql[i..].starts_with(delimiter) {
+                out.push_str(delimiter);
+                i += delimiter.len();
+                in_dollar_quote = None;
+                continue;
+            }
+
+            let ch = sql[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
+
         if in_line_comment {
             let ch = sql[i..].chars().next().unwrap();
             push_comment_char_sanitized(&mut out, ch);
@@ -3653,6 +3686,15 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
         }
 
         let ch = sql[i..].chars().next().unwrap();
+
+        if let Some(delimiter) = dollar_quote_delimiter_at(sql, i) {
+            if sql[i + delimiter.len()..].contains(delimiter) {
+                out.push_str(delimiter);
+                i += delimiter.len();
+                in_dollar_quote = Some(delimiter.to_string());
+                continue;
+            }
+        }
 
         if in_single {
             out.push(ch);
@@ -6610,6 +6652,17 @@ FROM orders"#;
         assert!(sanitized.contains("\"東京\""));
         assert!(!sanitized.contains("résumé"));
         assert!(!sanitized.ends_with("東京"));
+        assert_eq!(sanitized.len(), sql.len());
+    }
+
+    #[test]
+    fn test_comment_sanitizer_preserves_dollar_quoted_strings() {
+        let sql = "SELECT $$-- café$$ AS label, $tag$/* 東京 */$tag$ AS note FROM t -- résumé";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("$$-- café$$"));
+        assert!(sanitized.contains("$tag$/* 東京 */$tag$"));
+        assert!(!sanitized.ends_with("résumé"));
         assert_eq!(sanitized.len(), sql.len());
     }
 

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3687,15 +3687,6 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
 
         let ch = sql[i..].chars().next().unwrap();
 
-        if let Some(delimiter) = dollar_quote_delimiter_at(sql, i) {
-            if sql[i + delimiter.len()..].contains(delimiter) {
-                out.push_str(delimiter);
-                i += delimiter.len();
-                in_dollar_quote = Some(delimiter.to_string());
-                continue;
-            }
-        }
-
         if in_single {
             out.push(ch);
             i += ch.len_utf8();
@@ -3740,6 +3731,15 @@ fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
                 in_bracket = false;
             }
             continue;
+        }
+
+        if let Some(delimiter) = dollar_quote_delimiter_at(sql, i) {
+            if sql[i + delimiter.len()..].contains(delimiter) {
+                out.push_str(delimiter);
+                i += delimiter.len();
+                in_dollar_quote = Some(delimiter.to_string());
+                continue;
+            }
         }
 
         if i + 1 < bytes.len() && bytes[i] == b'-' && bytes[i + 1] == b'-' {
@@ -6663,6 +6663,18 @@ FROM orders"#;
         assert!(sanitized.contains("$$-- café$$"));
         assert!(sanitized.contains("$tag$/* 東京 */$tag$"));
         assert!(!sanitized.ends_with("résumé"));
+        assert_eq!(sanitized.len(), sql.len());
+    }
+
+    #[test]
+    fn test_comment_sanitizer_ignores_dollar_tags_inside_regular_strings() {
+        let sql = "SELECT '$tag$' AS label FROM t -- $tag$ café";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("'$tag$'"));
+        assert!(sanitized.contains("-- $tag$ caf"));
+        assert!(!sanitized.ends_with("café"));
+        assert!(sanitized.is_ascii());
         assert_eq!(sanitized.len(), sql.len());
     }
 

--- a/yardstick-rs/src/sql/measures.rs
+++ b/yardstick-rs/src/sql/measures.rs
@@ -3606,6 +3606,129 @@ fn is_interval_date_part_keyword(ident: &str) -> bool {
     parts.iter().any(|p| p.eq_ignore_ascii_case(ident))
 }
 
+fn push_comment_char_sanitized(out: &mut String, ch: char) {
+    if ch.is_ascii() {
+        out.push(ch);
+    } else {
+        for _ in 0..ch.len_utf8() {
+            out.push(' ');
+        }
+    }
+}
+
+fn sanitize_non_ascii_in_sql_comments(sql: &str) -> String {
+    let bytes = sql.as_bytes();
+    let mut out = String::with_capacity(sql.len());
+    let mut i = 0;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_backtick = false;
+    let mut in_bracket = false;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+
+    while i < bytes.len() {
+        if in_line_comment {
+            let ch = sql[i..].chars().next().unwrap();
+            push_comment_char_sanitized(&mut out, ch);
+            i += ch.len_utf8();
+            if ch == '\n' || ch == '\r' {
+                in_line_comment = false;
+            }
+            continue;
+        }
+
+        if in_block_comment {
+            if i + 1 < bytes.len() && bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                out.push_str("*/");
+                i += 2;
+                in_block_comment = false;
+                continue;
+            }
+
+            let ch = sql[i..].chars().next().unwrap();
+            push_comment_char_sanitized(&mut out, ch);
+            i += ch.len_utf8();
+            continue;
+        }
+
+        let ch = sql[i..].chars().next().unwrap();
+
+        if in_single {
+            out.push(ch);
+            i += ch.len_utf8();
+            if ch == '\'' {
+                if i < bytes.len() && bytes[i] == b'\'' {
+                    out.push('\'');
+                    i += 1;
+                } else {
+                    in_single = false;
+                }
+            }
+            continue;
+        }
+
+        if in_double {
+            out.push(ch);
+            i += ch.len_utf8();
+            if ch == '"' {
+                if i < bytes.len() && bytes[i] == b'"' {
+                    out.push('"');
+                    i += 1;
+                } else {
+                    in_double = false;
+                }
+            }
+            continue;
+        }
+
+        if in_backtick {
+            out.push(ch);
+            i += ch.len_utf8();
+            if ch == '`' {
+                in_backtick = false;
+            }
+            continue;
+        }
+
+        if in_bracket {
+            out.push(ch);
+            i += ch.len_utf8();
+            if ch == ']' {
+                in_bracket = false;
+            }
+            continue;
+        }
+
+        if i + 1 < bytes.len() && bytes[i] == b'-' && bytes[i + 1] == b'-' {
+            out.push_str("--");
+            i += 2;
+            in_line_comment = true;
+            continue;
+        }
+
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            out.push_str("/*");
+            i += 2;
+            in_block_comment = true;
+            continue;
+        }
+
+        out.push(ch);
+        i += ch.len_utf8();
+
+        match ch {
+            '\'' => in_single = true,
+            '"' => in_double = true,
+            '`' => in_backtick = true,
+            '[' => in_bracket = true,
+            _ => {}
+        }
+    }
+
+    out
+}
+
 // =============================================================================
 // Core Functions - Process CREATE VIEW
 // =============================================================================
@@ -3676,9 +3799,11 @@ pub fn process_create_view(sql: &str) -> CreateViewResult {
 fn extract_measures_from_sql(
     sql: &str,
 ) -> Result<(String, Vec<ViewMeasure>, Option<String>, Option<String>)> {
+    let sanitized_sql = sanitize_non_ascii_in_sql_comments(sql);
+    let sql = sanitized_sql.as_str();
     let view_name = extract_view_name(sql);
     let base_table = extract_table_name_from_sql(sql);
-    let sql_upper = sql.to_uppercase();
+    let sql_upper = sql.to_ascii_uppercase();
 
     // First pass: collect all measures with positions
     struct MeasureInfo {
@@ -6451,6 +6576,41 @@ mod tests {
         assert_eq!(result.measures[0].expression, "SUM(amount)");
         assert!(result.clean_sql.contains("AS revenue"));
         assert!(!result.clean_sql.contains("AS MEASURE"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_process_create_view_sanitizes_non_ascii_comments() {
+        clear_measure_views();
+
+        let sql = r#"CREATE VIEW orders_comment AS
+SELECT status, -- café
+SUM(amount) AS MEASURE revenue /* 東京 */
+FROM orders"#;
+        let result = std::panic::catch_unwind(|| process_create_view(sql))
+            .expect("non-ASCII comments must not panic");
+
+        assert!(result.is_measure_view);
+        assert!(result.error.is_none());
+        assert_eq!(result.measures.len(), 1);
+        assert_eq!(result.measures[0].column_name, "revenue");
+        assert!(result.clean_sql.is_ascii());
+        assert!(result.clean_sql.contains("-- caf"));
+        assert!(result.clean_sql.contains("/*"));
+        assert!(!result.clean_sql.contains("café"));
+        assert!(!result.clean_sql.contains("東京"));
+    }
+
+    #[test]
+    fn test_comment_sanitizer_preserves_non_comment_unicode() {
+        let sql = "SELECT 'café -- literal', \"東京\" /* résumé */ FROM t -- 東京";
+        let sanitized = sanitize_non_ascii_in_sql_comments(sql);
+
+        assert!(sanitized.contains("'café -- literal'"));
+        assert!(sanitized.contains("\"東京\""));
+        assert!(!sanitized.contains("résumé"));
+        assert!(!sanitized.ends_with("東京"));
+        assert_eq!(sanitized.len(), sql.len());
     }
 
     #[test]


### PR DESCRIPTION
Sanitizes non-ASCII characters inside SQL comments before rewritten CREATE VIEW definitions are parsed/executed, while preserving non-comment SQL text. Adds regressions for both SEMANTIC and parser-override paths with line and block comments containing non-ASCII characters.\n\nValidation:\n- cargo build --release\n- cargo test --no-run\n- make test